### PR TITLE
38 sviluppo api rest per inserimento delle assenze

### DIFF
--- a/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
+++ b/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
@@ -217,7 +217,7 @@ public class AbsencesGroupsController {
           description = "Persona non trovata con l'id e/o il codice fiscale fornito",
           content = @Content)
   })
-  @GetMapping("/absencesForm/groupsForCategory")
+  @GetMapping("/groupsForCategory")
   public ResponseEntity<AbsenceFormDto> getGroupsForCategory(
       @RequestParam("id") Optional<Long> id,
       @RequestParam("fiscalCode") Optional<String> fiscalCode,
@@ -303,7 +303,7 @@ public class AbsencesGroupsController {
           description = "Persona non trovata con l'id e/o il codice fiscale fornito",
           content = @Content)
   })
-  @PostMapping("/absencesForm/insertSimulation")
+  @PostMapping("/insertSimulation")
   public ResponseEntity<AbsenceFormSimulationResponseDto> insertSimulation(
       @NotNull @Valid @RequestBody AbsenceFormSimulationDto simulationDto) {
 
@@ -376,10 +376,10 @@ public class AbsencesGroupsController {
   }
 
   /**
-   * Simula l'inserimento dell'assenza.
+   * Salva l'assenza.
    */
   @Operation(
-      summary = "simula l'inserimento dell'assenza.",
+      summary = "salva l'assenza.",
       description = "Questo endpoint è utilizzabile dagli utenti con ruolo "
           + "'Gestore Assenze', 'Amministratore Personale' o "
           + "'Amministratore Personale sola lettura' della sede a "
@@ -387,7 +387,7 @@ public class AbsencesGroupsController {
           + "di sistema 'Developer' e/o 'Admin' oppure dall'utente relativo alle assenze")
   @ApiResponses(value = {
       @ApiResponse(responseCode = "200",
-          description = "Restituisce le informazioni associate alla simulazione dell'inserimento di un'assenza"),
+          description = "Restituisce l'id della persona, mese e anno dell'assenza e se è stata inserita o meno."),
       @ApiResponse(responseCode = "401",
           description = "Autenticazione non presente", content = @Content),
       @ApiResponse(responseCode = "403",
@@ -398,7 +398,7 @@ public class AbsencesGroupsController {
           description = "Persona non trovata con l'id e/o il codice fiscale fornito",
           content = @Content)
   })
-  @PostMapping("/absencesForm/save")
+  @PostMapping("/save")
   public ResponseEntity<AbsenceFormSaveResponseDto> saveAbsenceForm(
       @NotNull @Valid @RequestBody AbsenceFormSaveDto absenceFormSaveDto) {
 
@@ -499,7 +499,7 @@ public class AbsencesGroupsController {
           description = "Persona non trovata con l'id e/o il codice fiscale fornito",
           content = @Content)
   })
-  @GetMapping("/absencesForm/findCode")
+  @GetMapping("/findCode")
   public ResponseEntity<Set<AbsenceTypeDto>> findCode(
       @RequestParam("id") Optional<Long> id,
       @RequestParam("fiscalCode") Optional<String> fiscalCode,

--- a/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
+++ b/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
@@ -35,6 +35,7 @@ import it.cnr.iit.epas.dao.AbsenceTypeDao;
 import it.cnr.iit.epas.dao.CategoryTabDao;
 import it.cnr.iit.epas.dao.GroupAbsenceTypeDao;
 import it.cnr.iit.epas.dao.absences.AbsenceComponentDao;
+import it.cnr.iit.epas.dto.v4.AbsenceErrorDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormSaveDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormSaveResponseDto;
@@ -56,12 +57,14 @@ import it.cnr.iit.epas.manager.recaps.absencegroups.AbsenceGroupsRecapFactory;
 import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
 import it.cnr.iit.epas.manager.services.absences.AbsenceService;
 import it.cnr.iit.epas.manager.services.absences.AbsenceService.InsertReport;
+import it.cnr.iit.epas.manager.services.absences.errors.AbsenceError;
 import it.cnr.iit.epas.manager.services.absences.model.AbsencePeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod.TemplateRow;
 import it.cnr.iit.epas.models.Person;
 import it.cnr.iit.epas.models.Role;
 import it.cnr.iit.epas.models.User;
+import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.absences.AbsenceType;
 import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
 import it.cnr.iit.epas.models.absences.CategoryTab;
@@ -426,6 +429,9 @@ public class AbsencesGroupsController {
         absenceService.buildAbsenceForm(person, dateFrom, categoryTab,
             dateTo, recoveryDate, groupAbsenceType, switchGroup, absenceType,
             justifiedType, hours, minutes, false, false);
+
+    log.debug("AbsenceController::simulateInsert justifiedType={}",
+        absenceForm.justifiedTypeSelected);
 
     InsertReport insertReport = absenceService.insert(person,
         absenceForm.groupSelected,

--- a/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
+++ b/src/main/java/it/cnr/iit/epas/controller/v4/AbsencesGroupsController.java
@@ -29,29 +29,36 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import it.cnr.iit.epas.config.OpenApiConfiguration;
 import it.cnr.iit.epas.controller.v4.utils.ApiRoutes;
 import it.cnr.iit.epas.controller.v4.utils.PersonFinder;
+import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
 import it.cnr.iit.epas.dto.v4.AbsenceGroupsDto;
 import it.cnr.iit.epas.dto.v4.AbsencePeriodTerseDto;
+import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.CategoryTabDto;
 import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
 import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
 import it.cnr.iit.epas.dto.v4.PeriodChainDto;
 import it.cnr.iit.epas.dto.v4.TemplateRowDto;
+import it.cnr.iit.epas.dto.v4.mapper.AbsenceFormMapper;
 import it.cnr.iit.epas.dto.v4.mapper.AbsenceGroupsMapper;
 import it.cnr.iit.epas.manager.recaps.absencegroups.AbsenceGroupsRecap;
 import it.cnr.iit.epas.manager.recaps.absencegroups.AbsenceGroupsRecapFactory;
+import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
+import it.cnr.iit.epas.manager.services.absences.AbsenceService;
 import it.cnr.iit.epas.manager.services.absences.model.AbsencePeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod.TemplateRow;
+import it.cnr.iit.epas.models.Person;
 import it.cnr.iit.epas.models.absences.GroupAbsenceType;
 import it.cnr.iit.epas.security.SecurityRules;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
 import javax.persistence.EntityNotFoundException;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -78,6 +85,8 @@ public class AbsencesGroupsController {
 
   private final AbsenceGroupsRecapFactory absenceGroupsRecapFactory;
   private final AbsenceGroupsMapper absenceGroupsMapper;
+  private final AbsenceFormMapper absenceFormMapper;
+  private final AbsenceService absenceService;
   private final PersonFinder personFinder;
   private final SecurityRules rules;
 
@@ -112,8 +121,8 @@ public class AbsencesGroupsController {
       @RequestParam("from") String from) {
     log.debug("AbsencesGroupsController::groupStatus groupAbsenceTypeId = {} from = {}",
         groupAbsenceTypeId, from);
-    val fromLocalDate = LocalDate.parse(from);
-    val person =
+    LocalDate fromLocalDate = LocalDate.parse(from);
+    Person person =
         personFinder.getPerson(id, fiscalCode)
             .orElseThrow(() -> new EntityNotFoundException("Person not found"));
 
@@ -126,9 +135,9 @@ public class AbsencesGroupsController {
     List<AbsencePeriodTerseDto> newPeriodDto = Lists.newArrayList();
 
     for (AbsencePeriod sp : psrDto.periodChain.periods) {
-      val aspDto = absenceGroupsMapper.convertAbsencePeriodTerse(sp);
+      AbsencePeriodTerseDto aspDto = absenceGroupsMapper.convertAbsencePeriodTerse(sp);
       for (DayInPeriod dp : sp.daysInPeriod.values()) {
-        val dpDto = absenceGroupsMapper.convertDayInPeriod(dp);
+        DayInPeriodDto dpDto = absenceGroupsMapper.convertDayInPeriod(dp);
         List<TemplateRowDto> tp = Lists.newArrayList();
         for (TemplateRow tr : dp.allTemplateRows()) {
           tp.add(absenceGroupsMapper.convertTemplateRow(tr));
@@ -154,4 +163,77 @@ public class AbsencesGroupsController {
     return ResponseEntity.ok().body(absGroupDto);
   }
 
+  /**
+   * Recupero le informazioni per costruire la form dell'inserimento assenza sistemare descrizione
+   * sotto.
+   */
+  @Operation(
+      summary = "Visualizzazione della lista delle assenza di una persona in un mese.",
+      description = "Questo endpoint è utilizzabile dagli utenti con ruolo "
+          + "'Gestore Assenze', 'Amministratore Personale' o "
+          + "'Amministratore Personale sola lettura' della sede a "
+          + "appartiene la persona di cui cercare le assenze e dagli utenti con il ruolo "
+          + "di sistema 'Developer' e/o 'Admin' oppure dall'utente relativo alle assenze")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200",
+          description = "Restituito l'elenco delle assenze in un mese"),
+      @ApiResponse(responseCode = "401",
+          description = "Autenticazione non presente", content = @Content),
+      @ApiResponse(responseCode = "403",
+          description = "Utente che ha effettuato la richiesta non autorizzato a visualizzare"
+              + " l'elenco delle assenze",
+          content = @Content),
+      @ApiResponse(responseCode = "404",
+          description = "Persona non trovata con l'id e/o il codice fiscale fornito",
+          content = @Content)
+  })
+  @GetMapping("/absencesForm")
+  public ResponseEntity<AbsenceFormDto> getAbsencesForm(
+      @RequestParam("id") Optional<Long> id,
+      @RequestParam("fiscalCode") Optional<String> fiscalCode,
+      @RequestParam("from") String from) {
+    log.debug("AbsencesGroupsController::getAbsencesForm id = {} from = {}", id, from);
+    LocalDate fromLocalDate = LocalDate.parse(from);
+
+    Person person =
+        personFinder.getPerson(id, fiscalCode)
+            .orElseThrow(() -> new EntityNotFoundException("Person not found"));
+
+    log.debug("AbsenceController::absencesInPeriod person = {}", person);
+
+    rules.checkifPermitted(person);
+
+    AbsenceForm absenceForm = absenceService.buildAbsenceForm(person, fromLocalDate,
+        null, null, null, null, true, null,
+        null, null, null, true, false);
+
+    log.debug("absenceForm::tabsVisibile = {}", absenceForm.tabsVisibile);
+
+    AbsenceFormDto absFormDto = absenceFormMapper.convert(absenceForm);
+    log.debug("absenceForm::groupsByCategory = {}", absenceForm.groups());
+//    Map<CategoryGroupAbsenceTypeDto, List<GroupAbsenceTypeDto>> groupsByCategory =
+//        Maps.newHashMap();
+//
+//    List<GroupAbsenceTypeDto> groupAbsenceTypeDto = Lists.newArrayList();
+//    List<GroupAbsenceTypeDto> groupAbsenceTypeDtoTmp;
+//
+//    CategoryGroupAbsenceTypeDto keyGroupMap;
+//    for (GroupAbsenceType gr : absenceForm.groups()) {
+//      groupAbsenceTypeDto.add(absenceGroupsMapper.convertGroupAbsenceType(gr));
+//      keyGroupMap = absenceFormMapper.convert(gr.category);
+//      groupAbsenceTypeDtoTmp = groupsByCategory.get(keyGroupMap);
+//      if (groupAbsenceTypeDtoTmp == null) {
+//        groupAbsenceTypeDtoTmp = Lists.newArrayList();
+//        groupAbsenceTypeDtoTmp.add(absenceGroupsMapper.convertGroupAbsenceType(gr));
+//        groupsByCategory.put(keyGroupMap, groupAbsenceTypeDtoTmp);
+//      } else {
+//        groupAbsenceTypeDtoTmp.add(absenceGroupsMapper.convertGroupAbsenceType(gr));
+//        groupsByCategory.replace(keyGroupMap, groupAbsenceTypeDtoTmp);
+//      }
+//    }
+//
+//    log.debug("absenceForm::groupsByCategory = {}", groupsByCategory.values());
+//    absFormDto.setgroupsByCategory(groupsByCategory);
+    return ResponseEntity.ok().body(absFormDto);
+  }
 }

--- a/src/main/java/it/cnr/iit/epas/dao/history/HistoricalDao.java
+++ b/src/main/java/it/cnr/iit/epas/dao/history/HistoricalDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.dao.history;
 
 import com.google.common.base.Verify;
@@ -29,8 +28,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
-import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.envers.AuditReaderFactory;
 import org.hibernate.envers.query.AuditEntity;
 import org.springframework.stereotype.Component;
@@ -160,4 +159,7 @@ public class HistoricalDao {
     return lastRevisionOf(entity.getClass(), entity.getId()).revision.owner;
   }
 
+  public Boolean isPersistent(BaseEntity entity) {
+    return emp.get().contains(entity);
+  }
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceErrorDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceErrorDto.java
@@ -20,6 +20,7 @@ package it.cnr.iit.epas.dto.v4;
 import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import lombok.Data;
 
 /**
@@ -29,24 +30,11 @@ import lombok.Data;
  *
  */
 @Data
-public class TemplateRowDto {
-
-  private LocalDate date;
-  private List<AbsenceErrorDto> absenceErrors = Lists.newArrayList();
-  private List<AbsenceErrorDto> absenceWarnings = Lists.newArrayList();
+public class AbsenceErrorDto {
 
   public AbsenceShowDto absence;
+  public String absenceProblem;
 
-  private GroupAbsenceTypeDto groupAbsenceType;
-  private boolean beforeInitialization = false;
-  private boolean usableColumn = false;
-  private String usableLimit;
-  private String usableTaken;
+  public Set<AbsenceShowDto> conflictingAbsences;
 
-  private boolean complationColumn = false;
-  private String consumedComplationBefore;
-  private String consumedComplationAbsence;
-  private String consumedComplationNext;
-
-  private boolean isReplacingRow = false;
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormDto.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.SortedMap;
+import lombok.Data;
+
+/**
+ * DTO per i gruppi di assenza.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class AbsenceFormDto {
+  @Schema(description = "Persona")
+  private PersonShowDto person;
+  // switch date
+  private LocalDate from;
+  private LocalDate to;
+  private List<GroupAbsenceTypeDto> groupsPermitted = Lists.newArrayList();
+  private SortedMap<Integer, CategoryTabDto> tabsVisibile = Maps.newTreeMap();
+  private boolean permissionDenied = false;
+
+  //tab selected
+  private CategoryTabDto categoryTabSelected;
+
+  private boolean hasGroupChoice;
+  private boolean hasAbsenceTypeChoice;
+  private boolean hasJustifiedTypeChoice;
+  private Long theOnlyAbsenceType;
+  private GroupAbsenceTypeDto groupSelected;
+
+  private boolean hasHourMinutesChoice;
+  private List<Integer> selectableHours;
+  private List<Integer> selectableMinutes;
+
+  //for those absences who need future recovery of time
+  private LocalDate recoveryDate;
+
+  //automatic choice
+  private boolean automaticChoiceExists;
+  private boolean automaticChoiceSelected;
+
+  //switch absenceType
+  private List<AbsenceTypeDto> absenceTypes;
+  private AbsenceTypeDto absenceTypeSelected;
+
+  //switch justifiedType
+  private List<String> justifiedTypes = Lists.newArrayList();
+  private String justifiedTypeSelected;
+
+  //quantity
+  private Integer minutes = 0;
+  private Integer hours = 0;}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormDto.java
@@ -20,8 +20,11 @@ package it.cnr.iit.epas.dto.v4;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.swagger.v3.oas.annotations.media.Schema;
+import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedMap;
 import lombok.Data;
 
@@ -44,13 +47,13 @@ public class AbsenceFormDto {
 
   //tab selected
   private CategoryTabDto categoryTabSelected;
-
   private boolean hasGroupChoice;
   private boolean hasAbsenceTypeChoice;
   private boolean hasJustifiedTypeChoice;
   private Long theOnlyAbsenceType;
   private GroupAbsenceTypeDto groupSelected;
-
+  private List<GroupAbsenceTypeDto> groups;
+  private Map<String, List<GroupAbsenceTypeDto>> groupsByCategory;
   private boolean hasHourMinutesChoice;
   private List<Integer> selectableHours;
   private List<Integer> selectableMinutes;

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSaveDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSaveDto.java
@@ -17,8 +17,8 @@
 
 package it.cnr.iit.epas.dto.v4;
 
+import java.util.Optional;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
  * DTO per le tab della modale delle assenze.
@@ -27,8 +27,16 @@ import lombok.EqualsAndHashCode;
  *
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class AbsenceFormSimulationDto extends AbsenceFormSaveDto {
-  private String categoryTabName;
-  private boolean switchGroup;
+public class AbsenceFormSaveDto {
+  private Optional<Long> idPerson;
+  private Optional<String> fiscalCode;
+  private String from;
+  private String to;
+  private String recoveryDate;
+  private String groupAbsenceTypeName;
+  private String absenceTypeCode;
+  private String justifiedTypeName;
+  private int hours;
+  private int minutes;
+  private boolean forceInsert;
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSaveResponseDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSaveResponseDto.java
@@ -17,8 +17,8 @@
 
 package it.cnr.iit.epas.dto.v4;
 
+import java.util.Optional;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
 
 /**
  * DTO per le tab della modale delle assenze.
@@ -27,8 +27,9 @@ import lombok.EqualsAndHashCode;
  *
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class AbsenceFormSimulationDto extends AbsenceFormSaveDto {
-  private String categoryTabName;
-  private boolean switchGroup;
+public class AbsenceFormSaveResponseDto {
+  private Long idPerson;
+  private int year;
+  private int month;
+  private boolean isSavedSuccessfully;
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSimulationDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSimulationDto.java
@@ -17,14 +17,9 @@
 
 package it.cnr.iit.epas.dto.v4;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.swagger.v3.oas.annotations.media.Schema;
 import it.cnr.iit.epas.models.absences.JustifiedType;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.SortedMap;
 import lombok.Data;
 
@@ -35,7 +30,19 @@ import lombok.Data;
  *
  */
 @Data
-public class AbsenceFormTabDto {
-  private SortedMap<Integer, CategoryTabDto> tabsVisibile = Maps.newTreeMap();
+public class AbsenceFormSimulationDto {
+  private Optional<Long> idPerson;
+  private Optional<String> fiscalCode;
+  private String from;
+  private String to;
+  private String categoryTabName;
+  private String groupAbsenceTypeName;
+  private String absenceTypeCode;
+  private String justifiedTypeName;
+  private int hours;
+  private int minutes;
+  private boolean forceInsert;
+  private boolean switchGroup;
+  private String recoveryDate;
 
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSimulationResponseDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormSimulationResponseDto.java
@@ -17,22 +17,29 @@
 
 package it.cnr.iit.epas.dto.v4;
 
-import it.cnr.iit.epas.models.absences.GroupAbsenceType.PeriodType;
+import com.google.common.collect.Lists;
+import java.util.List;
 import lombok.Data;
 
 /**
- * DTO per le tipologie di gruppi di assenze.
+ * DTO per la risposta della simulazione dell'inserimento assenza.
  *
  * @author Cristian Lucchesi
  *
  */
 @Data
-public class GroupAbsenceTypeDto {
-  private Long id;
-  private String name;
-  private String description;
-  private String chainDescription;
-  private boolean initializable;
-  private PeriodType periodType;
-  private GroupAbsenceTypeDto nextGroupToCheck;
+public class AbsenceFormSimulationResponseDto {
+  private List<CriticalErrorDto> criticalErrors = Lists.newArrayList();
+  private List<TemplateRowDto> insertTemplateRows = Lists.newArrayList();
+  private boolean usableColumn;
+  private boolean complationColumn;
+  private List<AbsenceShowDto> absencesToPersist = Lists.newArrayList();
+
+  private List<String> warningsPreviousVersion = Lists.newArrayList();
+
+  private int howManyWarning;
+  private int howManyError;
+  private int howManySuccess;
+  private int howManyReplacing;
+  private int howManyIgnored;
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormTabDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceFormTabDto.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.swagger.v3.oas.annotations.media.Schema;
+import it.cnr.iit.epas.models.absences.JustifiedType;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import lombok.Data;
+
+/**
+ * DTO per le tab della modale delle assenze.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class AbsenceFormTabDto {
+  private SortedMap<Integer, CategoryTabDto> tabsVisibile = Maps.newTreeMap();
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceTypeDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/AbsenceTypeDto.java
@@ -17,6 +17,7 @@
 
 package it.cnr.iit.epas.dto.v4;
 
+import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -34,5 +35,9 @@ public class AbsenceTypeDto extends BaseModelDto {
   private String description;
   private boolean hasGroups;
   private Integer numberOfDays = 0;
+
+  private String defaultTakableGroup;
+
+  private Optional<String> categoryTabName=null;
 
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/CategoryGroupAbsenceTypeDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/CategoryGroupAbsenceTypeDto.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
+import lombok.Data;
+
+/**
+ * DTO per le private ContractualClauseDto contractualClause;
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class CategoryGroupAbsenceTypeDto {
+
+  @Schema(description = "Nome categoria.")
+  private String name;
+  @Schema(description = "Descrizione categoria.")
+  private String description;
+  @Schema(description = "Priorità categoria.")
+  private int priority;
+  @Schema(description = "Tipologia di gruppo di assenze.")
+  private Set<GroupAbsenceTypeDto> groupAbsenceTypes;
+  @Schema(description = "Categorie di tab da mostrare nel menu per la gestione delle assenze.")
+  private CategoryTabDto tab;
+  @Schema(description = "Documentazione delle varie disposizioni contrattuali raggruppate per tipologia di assenza")
+  private ContractualClauseDto contractualClause;
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/CategoryTabDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/CategoryTabDto.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import com.google.common.collect.Sets;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
+import lombok.Data;
+
+/**
+ * DTO per le categorie di tab da mostrare nel menu per la gestione delle assenze.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class CategoryTabDto {
+
+  @Schema(description = "Nome della tab.")
+  private String name;
+  @Schema(description = "Descrizione della tab.")
+  private String description;
+  @Schema(description = "Priorità della tab.")
+  private int priority;
+  @Schema(description = "Indica se la tab è di default o meno.")
+  private boolean isDefault = false;
+//  @Schema(description = "Tipologie di gruppi di assenze e le tab in cui mostrarle.")
+//  private Set<CategoryGroupAbsenceTypeDto> categoryGroupAbsenceTypes = Sets.newHashSet();
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/ContractualClauseDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/ContractualClauseDto.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import com.google.common.collect.Sets;
+import io.swagger.v3.oas.annotations.media.Schema;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType.PeriodType;
+import it.cnr.iit.epas.models.enumerate.ContractualClauseContext;
+import java.util.Set;
+import lombok.Data;
+
+/**
+ * DTO per le tipologie di gruppi di assenze.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class ContractualClauseDto {
+  @Schema(description = "Esempio: Permessi retribuiti (art. 72)")
+  private String name;
+  @Schema(description = "Tempi di fruizione.")
+  private String fruitionTime;
+  @Schema(description = "Caratteristiche Giuridico Economiche.")
+  private String legalAndEconomic;
+  @Schema(description = "Documentazione giustificativa.")
+  private String supportingDocumentation;
+  @Schema(description = "Modalità di richiesta.")
+  private String howToRequest;
+  @Schema(description = "Altre informazioni")
+  private String otherInfos;
+  @Schema(description = "Contesto a cui si applicano le clausole contrattuali.")
+  private String context;
+//  @Schema(description = "Tipologie di gruppi di assenze.")
+//  private Set<CategoryGroupAbsenceTypeDto> categoryGroupAbsenceTypes = Sets.newHashSet();
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/CriticalErrorDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/CriticalErrorDto.java
@@ -17,22 +17,22 @@
 
 package it.cnr.iit.epas.dto.v4;
 
-import it.cnr.iit.epas.models.absences.GroupAbsenceType.PeriodType;
+import java.time.LocalDate;
 import lombok.Data;
 
 /**
- * DTO per le tipologie di gruppi di assenze.
+ * DTO per i gli errori critici.
  *
  * @author Cristian Lucchesi
  *
  */
 @Data
-public class GroupAbsenceTypeDto {
-  private Long id;
-  private String name;
-  private String description;
-  private String chainDescription;
-  private boolean initializable;
-  private PeriodType periodType;
-  private GroupAbsenceTypeDto nextGroupToCheck;
+public class CriticalErrorDto {
+  private String criticalProblem;
+  private LocalDate date;
+  private GroupAbsenceTypeDto groupAbsenceType;
+  private String justifiedType;
+  private AbsenceTypeDto absenceType;
+  private AbsenceTypeDto conflictingAbsenceType;
+  private AbsenceShowDto absence;
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/JustifiedTypeDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/JustifiedTypeDto.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import it.cnr.iit.epas.models.absences.GroupAbsenceType.PeriodType;
+import lombok.Data;
+
+/**
+ * DTO per le tipologie di gruppi di assenze.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class JustifiedTypeDto {
+  private String label;
+  private String name;
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/QualificationDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/QualificationDto.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4;
+
+import com.google.common.collect.Sets;
+import io.swagger.v3.oas.annotations.media.Schema;
+import it.cnr.iit.epas.models.Person;
+import java.util.List;
+import java.util.Set;
+import lombok.Data;
+
+/**
+ * DTO per le categorie di tab da mostrare nel menu per la gestione delle assenze.
+ *
+ * @author Cristian Lucchesi
+ *
+ */
+@Data
+public class QualificationDto {
+
+  private List<Person> person;
+  private int qualification;
+  private String description;
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/TemplateRowDto.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/TemplateRowDto.java
@@ -37,6 +37,8 @@ public class TemplateRowDto {
 
   public AbsenceShowDto absence;
 
+  public boolean onlyNotOnHoliday;
+
   private GroupAbsenceTypeDto groupAbsenceType;
   private boolean beforeInitialization = false;
   private boolean usableColumn = false;

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4.mapper;
+import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
+import it.cnr.iit.epas.dto.v4.AbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.ContractualClauseDto;
+import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.PersonShowDto;
+import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
+import it.cnr.iit.epas.models.Person;
+import it.cnr.iit.epas.models.absences.AbsenceType;
+import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType;
+import it.cnr.iit.epas.models.absences.JustifiedType;
+import it.cnr.iit.epas.models.contractuals.ContractualClause;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Mapper da AbsenceGroups al suo DTO per la visualizzazione via REST.
+ */
+@Mapper(componentModel = "spring")
+public interface AbsenceFormMapper {
+  @Mapping(target = "justifiedTypeSelected", source = "justifiedTypeSelected.name")
+  @Mapping(target = "hasGroupChoice", expression = "java(absenceForm.hasGroupChoice())")
+  @Mapping(target = "hasAbsenceTypeChoice", expression = "java(absenceForm.hasAbsenceTypeChoice())")
+  @Mapping(target = "hasJustifiedTypeChoice", expression = "java(absenceForm.hasJustifiedTypeChoice())")
+//  @Mapping(target = "theOnlyAbsenceType", expression = "java(absenceForm.theOnlyAbsenceType().getId())")
+  @Mapping(target = "hasHourMinutesChoice", expression = "java(absenceForm.hasHourMinutesChoice())")
+  @Mapping(target = "selectableHours", expression = "java(absenceForm.selectableHours())")
+  @Mapping(target = "selectableMinutes", expression = "java(absenceForm.selectableMinutes())")
+  AbsenceFormDto convert(AbsenceForm absenceForm);
+
+  @Mapping(target = "qualification", source = "person.qualification.id")
+  PersonShowDto convert(Person person);
+
+  @Mapping(target = "hasGroups",
+      expression = "java(!absenceType.involvedGroupTaken(true).isEmpty())")
+  AbsenceTypeDto convert(AbsenceType absenceType);
+
+  GroupAbsenceTypeDto convert(GroupAbsenceType groupAbsenceType);
+  ContractualClauseDto convert(ContractualClause contractualClause);
+
+  CategoryGroupAbsenceTypeDto convert(CategoryGroupAbsenceType categoryGroupAbsenceType);
+
+  @Mapping(target = ".", source = "name")
+  String convert(JustifiedType justifiedType);
+
+
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormMapper.java
@@ -56,6 +56,8 @@ public interface AbsenceFormMapper {
 
   @Mapping(target = "hasGroups",
       expression = "java(!absenceType.involvedGroupTaken(true).isEmpty())")
+  @Mapping(target = "defaultTakableGroup",
+      expression = "java(absenceType.defaultTakableGroup().category.tab != null ? absenceType.defaultTakableGroup().category.tab.getLabel():null)")
   AbsenceTypeDto convert(AbsenceType absenceType);
 
   @Mapping(target = ".", source = "name")

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
@@ -16,6 +16,7 @@
  */
 
 package it.cnr.iit.epas.dto.v4.mapper;
+import it.cnr.iit.epas.dto.v4.AbsenceErrorDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormSimulationResponseDto;
 import it.cnr.iit.epas.dto.v4.AbsenceShowDto;
@@ -28,6 +29,7 @@ import it.cnr.iit.epas.dto.v4.PersonShowDto;
 import it.cnr.iit.epas.dto.v4.TemplateRowDto;
 import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
 import it.cnr.iit.epas.manager.services.absences.AbsenceService.InsertReport;
+import it.cnr.iit.epas.manager.services.absences.errors.AbsenceError;
 import it.cnr.iit.epas.manager.services.absences.errors.CriticalError;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod.TemplateRow;
@@ -49,9 +51,14 @@ public interface AbsenceFormSimulationResponseMapper {
 
   CriticalErrorDto convert(CriticalError criticalError);
 
+  @Mapping(target = "absenceProblem", source = "absence.absenceProblem")
+  AbsenceErrorDto convert(AbsenceError absence);
+
   @Mapping(target = "absence", source = "rowRecap.absence")
   TemplateRowDto convert(TemplateRow rowRecap);
 
+  @Mapping(target = "justifiedType", source = "absence.justifiedType.name")
+  @Mapping(target = "justifiedTime", expression = "java(absence.justifiedTime())")
   AbsenceShowDto convert(Absence absence);
 
   @Mapping(target = "howManySuccess", expression = "java(insertReport.howManySuccess())")

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
@@ -17,29 +17,16 @@
 
 package it.cnr.iit.epas.dto.v4.mapper;
 import it.cnr.iit.epas.dto.v4.AbsenceErrorDto;
-import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
 import it.cnr.iit.epas.dto.v4.AbsenceFormSimulationResponseDto;
 import it.cnr.iit.epas.dto.v4.AbsenceShowDto;
-import it.cnr.iit.epas.dto.v4.AbsenceTypeDto;
-import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
-import it.cnr.iit.epas.dto.v4.ContractualClauseDto;
 import it.cnr.iit.epas.dto.v4.CriticalErrorDto;
-import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
-import it.cnr.iit.epas.dto.v4.PersonShowDto;
 import it.cnr.iit.epas.dto.v4.TemplateRowDto;
-import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
 import it.cnr.iit.epas.manager.services.absences.AbsenceService.InsertReport;
 import it.cnr.iit.epas.manager.services.absences.errors.AbsenceError;
 import it.cnr.iit.epas.manager.services.absences.errors.CriticalError;
-import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod.TemplateRow;
-import it.cnr.iit.epas.models.Person;
 import it.cnr.iit.epas.models.absences.Absence;
-import it.cnr.iit.epas.models.absences.AbsenceType;
-import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
-import it.cnr.iit.epas.models.absences.GroupAbsenceType;
 import it.cnr.iit.epas.models.absences.JustifiedType;
-import it.cnr.iit.epas.models.contractuals.ContractualClause;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -55,6 +42,7 @@ public interface AbsenceFormSimulationResponseMapper {
   AbsenceErrorDto convert(AbsenceError absence);
 
   @Mapping(target = "absence", source = "rowRecap.absence")
+  @Mapping(target = "onlyNotOnHoliday", expression = "java(rowRecap.onlyNotOnHoliday())")
   TemplateRowDto convert(TemplateRow rowRecap);
 
   @Mapping(target = "justifiedType", source = "absence.justifiedType.name")

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormSimulationResponseMapper.java
@@ -17,13 +17,22 @@
 
 package it.cnr.iit.epas.dto.v4.mapper;
 import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
+import it.cnr.iit.epas.dto.v4.AbsenceFormSimulationResponseDto;
+import it.cnr.iit.epas.dto.v4.AbsenceShowDto;
 import it.cnr.iit.epas.dto.v4.AbsenceTypeDto;
 import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
 import it.cnr.iit.epas.dto.v4.ContractualClauseDto;
+import it.cnr.iit.epas.dto.v4.CriticalErrorDto;
 import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
 import it.cnr.iit.epas.dto.v4.PersonShowDto;
+import it.cnr.iit.epas.dto.v4.TemplateRowDto;
 import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
+import it.cnr.iit.epas.manager.services.absences.AbsenceService.InsertReport;
+import it.cnr.iit.epas.manager.services.absences.errors.CriticalError;
+import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
+import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod.TemplateRow;
 import it.cnr.iit.epas.models.Person;
+import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.absences.AbsenceType;
 import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
 import it.cnr.iit.epas.models.absences.GroupAbsenceType;
@@ -33,34 +42,25 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 /**
- * Mapper da AbsenceGroups al suo DTO per la visualizzazione via REST.
+ * Mapper da AbsenceFormSimulationResponse al suo DTO per la visualizzazione via REST.
  */
 @Mapper(componentModel = "spring")
-public interface AbsenceFormMapper {
+public interface AbsenceFormSimulationResponseMapper {
 
-  CategoryGroupAbsenceTypeDto convert(CategoryGroupAbsenceType categoryGroupAbsenceType);
-  GroupAbsenceTypeDto convert(GroupAbsenceType groupAbsenceType);
-  ContractualClauseDto convert(ContractualClause contractualClause);
-  @Mapping(target = "justifiedTypeSelected", source = "justifiedTypeSelected.name")
-  @Mapping(target = "hasGroupChoice", expression = "java(absenceForm.hasGroupChoice())")
-  @Mapping(target = "hasAbsenceTypeChoice", expression = "java(absenceForm.hasAbsenceTypeChoice())")
-  @Mapping(target = "hasJustifiedTypeChoice", expression = "java(absenceForm.hasJustifiedTypeChoice())")
-//  @Mapping(target = "theOnlyAbsenceType", expression = "java(absenceForm.theOnlyAbsenceType().getId())")
-  @Mapping(target = "hasHourMinutesChoice", expression = "java(absenceForm.hasHourMinutesChoice())")
-  @Mapping(target = "selectableHours", expression = "java(absenceForm.selectableHours())")
-  @Mapping(target = "selectableMinutes", expression = "java(absenceForm.selectableMinutes())")
-  AbsenceFormDto convert(AbsenceForm absenceForm);
+  CriticalErrorDto convert(CriticalError criticalError);
 
-  @Mapping(target = "qualification", source = "person.qualification.id")
-  PersonShowDto convert(Person person);
+  @Mapping(target = "absence", source = "rowRecap.absence")
+  TemplateRowDto convert(TemplateRow rowRecap);
 
-  @Mapping(target = "hasGroups",
-      expression = "java(!absenceType.involvedGroupTaken(true).isEmpty())")
-  AbsenceTypeDto convert(AbsenceType absenceType);
+  AbsenceShowDto convert(Absence absence);
+
+  @Mapping(target = "howManySuccess", expression = "java(insertReport.howManySuccess())")
+  @Mapping(target = "howManyReplacing", expression = "java(insertReport.howManyReplacing())")
+  @Mapping(target = "howManyIgnored", expression = "java(insertReport.howManyIgnored())")
+  @Mapping(target = "howManyError", expression = "java(insertReport.howManyError())")
+  AbsenceFormSimulationResponseDto convert(InsertReport insertReport);
 
   @Mapping(target = ".", source = "name")
   String convert(JustifiedType justifiedType);
-
-
 
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormTabMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormTabMapper.java
@@ -16,28 +16,9 @@
  */
 
 package it.cnr.iit.epas.dto.v4.mapper;
-
-import it.cnr.iit.epas.dto.v4.AbsenceGroupsDto;
-import it.cnr.iit.epas.dto.v4.AbsencePeriodTerseDto;
-import it.cnr.iit.epas.dto.v4.AbsenceShowTerseDto;
 import it.cnr.iit.epas.dto.v4.CategoryTabDto;
-import it.cnr.iit.epas.dto.v4.ComplationAbsenceDto;
-import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
-import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
-import it.cnr.iit.epas.dto.v4.PeriodChainDto;
-import it.cnr.iit.epas.dto.v4.TakenAbsenceDto;
-import it.cnr.iit.epas.dto.v4.TemplateRowDto;
-import it.cnr.iit.epas.manager.recaps.absencegroups.AbsenceGroupsRecap;
-import it.cnr.iit.epas.manager.services.absences.model.AbsencePeriod;
-import it.cnr.iit.epas.manager.services.absences.model.ComplationAbsence;
-import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
-import it.cnr.iit.epas.manager.services.absences.model.PeriodChain;
-import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
-import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.absences.CategoryTab;
-import it.cnr.iit.epas.models.absences.GroupAbsenceType;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 /**
  * Mapper da AbsenceFormTab al suo DTO per la visualizzazione via REST.

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormTabMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceFormTabMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4.mapper;
+
+import it.cnr.iit.epas.dto.v4.AbsenceGroupsDto;
+import it.cnr.iit.epas.dto.v4.AbsencePeriodTerseDto;
+import it.cnr.iit.epas.dto.v4.AbsenceShowTerseDto;
+import it.cnr.iit.epas.dto.v4.CategoryTabDto;
+import it.cnr.iit.epas.dto.v4.ComplationAbsenceDto;
+import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
+import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.PeriodChainDto;
+import it.cnr.iit.epas.dto.v4.TakenAbsenceDto;
+import it.cnr.iit.epas.dto.v4.TemplateRowDto;
+import it.cnr.iit.epas.manager.recaps.absencegroups.AbsenceGroupsRecap;
+import it.cnr.iit.epas.manager.services.absences.model.AbsencePeriod;
+import it.cnr.iit.epas.manager.services.absences.model.ComplationAbsence;
+import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
+import it.cnr.iit.epas.manager.services.absences.model.PeriodChain;
+import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
+import it.cnr.iit.epas.models.absences.Absence;
+import it.cnr.iit.epas.models.absences.CategoryTab;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Mapper da AbsenceFormTab al suo DTO per la visualizzazione via REST.
+ */
+@Mapper(componentModel = "spring")
+public interface AbsenceFormTabMapper {
+
+  CategoryTabDto convertCategoryTab(CategoryTab categoryTab);
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceGroupsMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/AbsenceGroupsMapper.java
@@ -19,6 +19,7 @@ package it.cnr.iit.epas.dto.v4.mapper;
 
 import it.cnr.iit.epas.dto.v4.AbsenceGroupsDto;
 import it.cnr.iit.epas.dto.v4.AbsencePeriodTerseDto;
+import it.cnr.iit.epas.dto.v4.AbsenceShowDto;
 import it.cnr.iit.epas.dto.v4.AbsenceShowTerseDto;
 import it.cnr.iit.epas.dto.v4.ComplationAbsenceDto;
 import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
@@ -34,21 +35,32 @@ import it.cnr.iit.epas.manager.services.absences.model.PeriodChain;
 import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
 import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.absences.GroupAbsenceType;
+import it.cnr.iit.epas.models.absences.JustifiedType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 /**
  * Mapper da AbsenceGroups al suo DTO per la visualizzazione via REST.
  */
 @Mapper(componentModel = "spring")
 public interface AbsenceGroupsMapper {
-
-  @Mapping(target = "justifiedType", source = "justifiedType.name")
+  @Named("toTerse")
   @Mapping(target = "externalId", source = "externalIdentifier")
   @Mapping(target = "justifiedTime", expression = "java(absence.justifiedTime())")
+  @Mapping(target = "justifiedType", source = "absence.justifiedType.name")
   @Mapping(target = "date", source = "personDay.date")
   @Mapping(target = "nothingJustified", expression = "java(absence.nothingJustified())")
-  AbsenceShowTerseDto convert(Absence absence);
+  AbsenceShowTerseDto convertToTerse(Absence absence);
+
+  @Named("toShow")
+  @Mapping(target = "externalId", source = "externalIdentifier")
+  @Mapping(target = "justifiedType", source = "absenceShow.justifiedType.name")
+  @Mapping(target = "justifiedTime", expression = "java(absenceShow.justifiedTime())")
+  @Mapping(target = "date", source = "personDay.date")
+  @Mapping(target = "nothingJustified", expression = "java(absenceShow.nothingJustified())")
+  AbsenceShowDto convertToShow(Absence absenceShow);
+
 
   @Mapping(target = "absence.justifiedType", source = "absence.justifiedType.name")
   TakenAbsenceDto convert(TakenAbsence takenAbsences);
@@ -59,6 +71,7 @@ public interface AbsenceGroupsMapper {
   AbsenceGroupsDto convert(AbsenceGroupsRecap absenceGroupsRecap);
 
   @Mapping(target = "absence", source = "rowRecap.absence")
+  @Mapping(target = "absence.justifiedType", source = "rowRecap.absence.justifiedType.name")
   TemplateRowDto convertTemplateRow(DayInPeriod.TemplateRow rowRecap);
 
   DayInPeriodDto convertDayInPeriod(DayInPeriod dayInPeriod);
@@ -68,6 +81,9 @@ public interface AbsenceGroupsMapper {
   AbsencePeriodTerseDto convertAbsencePeriodTerse(AbsencePeriod absencePeriod);
 
   PeriodChainDto convertPeriodChain(PeriodChain periodChain);
+
+  @Mapping(target = ".", source = "name")
+  String convert(JustifiedType justifiedType);
 
 
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryGroupAbsenceTypeMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryGroupAbsenceTypeMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4.mapper;
+
+import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
+import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
+import it.cnr.iit.epas.models.absences.CategoryTab;
+import org.mapstruct.Mapper;
+
+/**
+ * Mapper da CategoryTab al suo DTO per la visualizzazione via REST.
+ */
+@Mapper(componentModel = "spring")
+public interface CategoryGroupAbsenceTypeMapper {
+
+  CategoryGroupAbsenceTypeDto convert(CategoryGroupAbsenceType categoryGroupAbsenceTypeDto);
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryTabMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryTabMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4.mapper;
+
+import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
+import it.cnr.iit.epas.dto.v4.AbsenceShowTerseDto;
+import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.CategoryTabDto;
+import it.cnr.iit.epas.dto.v4.ComplationAbsenceDto;
+import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
+import it.cnr.iit.epas.dto.v4.TakenAbsenceDto;
+import it.cnr.iit.epas.dto.v4.TemplateRowDto;
+import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
+import it.cnr.iit.epas.manager.services.absences.model.ComplationAbsence;
+import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
+import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
+import it.cnr.iit.epas.models.absences.Absence;
+import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
+import it.cnr.iit.epas.models.absences.CategoryTab;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Mapper da CategoryTab al suo DTO per la visualizzazione via REST.
+ */
+@Mapper(componentModel = "spring")
+public interface CategoryTabMapper {
+
+  CategoryGroupAbsenceTypeDto convert(CategoryGroupAbsenceType categoryGroupAbsenceTypeDto);
+
+  CategoryTab convert(CategoryTab categoryTab);
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryTabMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CategoryTabMapper.java
@@ -17,23 +17,10 @@
 
 package it.cnr.iit.epas.dto.v4.mapper;
 
-import it.cnr.iit.epas.dto.v4.AbsenceFormDto;
-import it.cnr.iit.epas.dto.v4.AbsenceShowTerseDto;
 import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
-import it.cnr.iit.epas.dto.v4.CategoryTabDto;
-import it.cnr.iit.epas.dto.v4.ComplationAbsenceDto;
-import it.cnr.iit.epas.dto.v4.DayInPeriodDto;
-import it.cnr.iit.epas.dto.v4.TakenAbsenceDto;
-import it.cnr.iit.epas.dto.v4.TemplateRowDto;
-import it.cnr.iit.epas.manager.services.absences.AbsenceForm;
-import it.cnr.iit.epas.manager.services.absences.model.ComplationAbsence;
-import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
-import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
-import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
 import it.cnr.iit.epas.models.absences.CategoryTab;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 /**
  * Mapper da CategoryTab al suo DTO per la visualizzazione via REST.

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CriticalErrorMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CriticalErrorMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as
+ *     published by the Free Software Foundation, either version 3 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package it.cnr.iit.epas.dto.v4.mapper;
+
+import it.cnr.iit.epas.dto.v4.AbsenceShowDto;
+import it.cnr.iit.epas.dto.v4.AbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.CategoryTabDto;
+import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
+import it.cnr.iit.epas.models.absences.Absence;
+import it.cnr.iit.epas.models.absences.AbsenceType;
+import it.cnr.iit.epas.models.absences.CategoryTab;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType;
+import it.cnr.iit.epas.models.absences.JustifiedType;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Mapper da CriticalError al suo DTO per la visualizzazione via REST.
+ */
+@Mapper(componentModel = "spring")
+public interface CriticalErrorMapper {
+
+  GroupAbsenceTypeDto convert(GroupAbsenceType groupAbsenceType);
+  AbsenceTypeDto convert(AbsenceType absenceType);
+  AbsenceShowDto convert(Absence absence);
+
+  @Mapping(target = ".", source = "name")
+  String convert(JustifiedType justifiedType);
+
+}

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CriticalErrorMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/CriticalErrorMapper.java
@@ -37,6 +37,8 @@ public interface CriticalErrorMapper {
 
   GroupAbsenceTypeDto convert(GroupAbsenceType groupAbsenceType);
   AbsenceTypeDto convert(AbsenceType absenceType);
+  @Mapping(target = "justifiedType", source = "absence.justifiedType.name")
+  @Mapping(target = "justifiedTime", expression = "java(absence.justifiedTime())")
   AbsenceShowDto convert(Absence absence);
 
   @Mapping(target = ".", source = "name")

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/DayInPeriodMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/DayInPeriodMapper.java
@@ -26,6 +26,7 @@ import it.cnr.iit.epas.manager.services.absences.model.ComplationAbsence;
 import it.cnr.iit.epas.manager.services.absences.model.DayInPeriod;
 import it.cnr.iit.epas.manager.services.absences.model.TakenAbsence;
 import it.cnr.iit.epas.models.absences.Absence;
+import it.cnr.iit.epas.models.absences.JustifiedType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -36,7 +37,7 @@ import org.mapstruct.Mapping;
 public interface DayInPeriodMapper {
 
 
-  @Mapping(target = "justifiedType", source = "justifiedType.name")
+  @Mapping(target = "justifiedType", source = "absence.justifiedType.name")
   @Mapping(target = "externalId", source = "externalIdentifier")
   @Mapping(target = "justifiedTime", expression = "java(absence.justifiedTime())")
   @Mapping(target = "date", source = "personDay.date")
@@ -52,5 +53,7 @@ public interface DayInPeriodMapper {
   TemplateRowDto convert(DayInPeriod.TemplateRow rowRecap);
 
   DayInPeriodDto convert(DayInPeriod dayInPeriod);
+  @Mapping(target = ".", source = "name")
+  String convert(JustifiedType justifiedType);
 
 }

--- a/src/main/java/it/cnr/iit/epas/dto/v4/mapper/GroupAbsenceTypeMapper.java
+++ b/src/main/java/it/cnr/iit/epas/dto/v4/mapper/GroupAbsenceTypeMapper.java
@@ -15,24 +15,20 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package it.cnr.iit.epas.dto.v4;
+package it.cnr.iit.epas.dto.v4.mapper;
 
-import it.cnr.iit.epas.models.absences.GroupAbsenceType.PeriodType;
-import lombok.Data;
+import it.cnr.iit.epas.dto.v4.CategoryGroupAbsenceTypeDto;
+import it.cnr.iit.epas.dto.v4.GroupAbsenceTypeDto;
+import it.cnr.iit.epas.models.absences.CategoryGroupAbsenceType;
+import it.cnr.iit.epas.models.absences.CategoryTab;
+import it.cnr.iit.epas.models.absences.GroupAbsenceType;
+import org.mapstruct.Mapper;
 
 /**
- * DTO per le tipologie di gruppi di assenze.
- *
- * @author Cristian Lucchesi
- *
+ * Mapper da CategoryTab al suo DTO per la visualizzazione via REST.
  */
-@Data
-public class GroupAbsenceTypeDto {
-  private Long id;
-  private String name;
-  private String description;
-  private String chainDescription;
-  private boolean initializable;
-  private PeriodType periodType;
-  private GroupAbsenceTypeDto nextGroupToCheck;
+@Mapper(componentModel = "spring")
+public interface GroupAbsenceTypeMapper {
+
+  GroupAbsenceTypeDto convert(GroupAbsenceType groupAbsenceType);
 }

--- a/src/main/java/it/cnr/iit/epas/models/absences/AbsenceType.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/AbsenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences;
 
 import com.google.common.base.Joiner;
@@ -88,7 +87,6 @@ public class AbsenceType extends BaseEntity {
   @Column(name = "considered_week_end")
   private boolean consideredWeekEnd = false;
 
-  //FIXME: da implementare prima del passaggio a spring boot
   //  @Getter
   //  @Column(name = "time_for_mealticket")
   //  public boolean timeForMealTicket = false;
@@ -145,6 +143,8 @@ public class AbsenceType extends BaseEntity {
   private boolean reperibilityCompatible;
 
   private boolean isRealAbsence = true;
+
+  private String externalId;
 
   // Metodi
   

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultAbsenceType.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultAbsenceType.java
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.ImmutableSet;
@@ -36,11 +35,16 @@ import java.util.Set;
  *
  */
 public enum DefaultAbsenceType {
+  
+  A_COMANDO("COMANDO",
+      "Parziale nel mese", false,
+      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, MealTicketBehaviour.notAllowMealTicket, 
+      0, null, Sets.newHashSet(), LocalDate.of(2023, 12, 1), null, true, false, true, null),
 
   A_VAC19("VAC-19",
       "Assenza per la somministrazione del vaccino contro il COVID-19", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, MealTicketBehaviour.notAllowMealTicket, 
-      0, null, Sets.newHashSet(), LocalDate.of(2022, 1, 1), null, true, false, true),
+      0, null, Sets.newHashSet(), LocalDate.of(2022, 1, 1), null, true, false, true, null),
 
   A_SMART("SMART",
       "Smartworking a completamento", false,
@@ -52,26 +56,26 @@ public enum DefaultAbsenceType {
       "Lavoro agile", false,
       ImmutableSet.of(JustifiedTypeName.complete_day_and_add_overtime), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
-      LocalDate.of(2022, 3, 29), null, true, false, true),
+      LocalDate.of(2022, 3, 29), null, true, false, true, null),
 
   A_LAGILEBP("L-AGILE",
       "Lavoro agile con maturazione buono pasto", false,
       ImmutableSet.of(JustifiedTypeName.assign_all_day), 0, false, 
       MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), 
-      LocalDate.of(2022, 3, 29), LocalDate.of(2022, 6, 28), true, false, true),
+      LocalDate.of(2022, 3, 29), LocalDate.of(2022, 6, 28), true, false, true, null),
 
   A_COVID19("COVID19",
       "Emergenza coronavirus, attività lavorativa presso il domicilio dei dipendenti", false,
       ImmutableSet.of(JustifiedTypeName.assign_all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), null, 
-      LocalDate.of(2022, 4, 15), true, false, true),
+      LocalDate.of(2022, 4, 15), true, false, true, null),
 
   A_COVID19BP("COVID19",
       "Emergenza coronavirus, attività lavorativa presso il domicilio dei dipendenti "
           + "con maturazione buono pasto", false,
           ImmutableSet.of(JustifiedTypeName.assign_all_day), 0, false, 
           MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), null, 
-          LocalDate.of(2022, 4, 15), true, false, true),
+          LocalDate.of(2022, 4, 15), true, false, true, null),
 
   A_98CV("98CV",
       "Assente ingiustificato no greenpass", false,
@@ -83,7 +87,7 @@ public enum DefaultAbsenceType {
       "Lavoro agile per dipendenti fragili o per assistenza a disabile/immunodepresso", false,
       ImmutableSet.of(JustifiedTypeName.assign_all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
-      null, null, true, false, true),
+      null, null, true, false, true, null),
 
   A_39LANOBP("39LA",
       "Lavoro agile per dipendenti fragili o per assistenza a disabile/immunodepresso "
@@ -96,7 +100,7 @@ public enum DefaultAbsenceType {
       "Lavoro agile per quarantena/isolamento fiduciario", false,
       ImmutableSet.of(JustifiedTypeName.assign_all_day), 0, false, 
       MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), null, 
-      LocalDate.of(2022, 7, 1), true, false, true),
+      LocalDate.of(2022, 7, 1), true, false, true, null),
 
   A_18M("18M", "Permesso assistenza parenti/affini disabili L. 104/92 in ore e minuti", true,
       ImmutableSet.of(JustifiedTypeName.specified_minutes), 0, false, 
@@ -318,7 +322,7 @@ public enum DefaultAbsenceType {
       Sets.newHashSet(new Behaviour(JustifiedBehaviourName.no_overtime),
           new Behaviour(JustifiedBehaviourName.minimumTime, 60),
           new Behaviour(JustifiedBehaviourName.maximumTime, 300)),
-      LocalDate.of(2018, 7, 1), null, true, true, true),
+      LocalDate.of(2018, 7, 1), null, true, true, true, "F"),
 
   A_661G("661G", "Permesso orario per motivi personali intera giornata", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
@@ -482,16 +486,16 @@ public enum DefaultAbsenceType {
 
   A_92("92", "Missione", false, ImmutableSet.of(JustifiedTypeName.complete_day_and_add_overtime), 0,
       true, MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
-      null, null, false, true, true), 
+      null, null, false, true, true, "T"), 
   A_92E("92E", "Missione all'estero", false,
       ImmutableSet.of(JustifiedTypeName.complete_day_and_add_overtime), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true),
+      Sets.newHashSet(), null, null, false, true, true, "T"),
 
   A_92M("92M", "Missione in ore e minuti", true,
       ImmutableSet.of(JustifiedTypeName.specified_minutes), 0, false, 
       MealTicketBehaviour.allowMealTicket, 0, null,
-      Sets.newHashSet(), LocalDate.of(2019, 2, 1), null, false, true, true), 
+      Sets.newHashSet(), LocalDate.of(2019, 2, 1), null, false, true, true, "T"), 
   A_92NG("92", "Missione che non giustifica niente ai fini del tempo a lavoro", false,
       ImmutableSet.of(JustifiedTypeName.nothing), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
@@ -499,7 +503,7 @@ public enum DefaultAbsenceType {
   A_92RE("92RE", "Missione comune residenza BP", false,
       ImmutableSet.of(JustifiedTypeName.complete_day_and_add_overtime), 0, false, 
       MealTicketBehaviour.allowMealTicket, 0,
-      null, Sets.newHashSet(), LocalDate.of(2019, 4, 1), null, false, true, true),
+      null, Sets.newHashSet(), LocalDate.of(2019, 4, 1), null, false, true, true, "T"),
 
   A_92H1("92H1", "Missione 1 ora", false, ImmutableSet.of(JustifiedTypeName.nothing), 0, false,
       MealTicketBehaviour.notAllowMealTicket, 60, JustifiedTypeName.absence_type_minutes, 
@@ -572,11 +576,23 @@ public enum DefaultAbsenceType {
   //      ImmutableSet.of(JustifiedTypeName.all_day), 
   //      0, false, false, 0, null, Sets.newHashSet(), new LocalDate(2021, 1, 1), 
   //      new LocalDate(2021, 2, 15), false, true, true),
-  A_31_2020("31", "Ferie anno 2020 prorogate", false, 
+  //  A_31_2020("31", "Ferie anno 2020 prorogate", false, 
+  //      ImmutableSet.of(JustifiedTypeName.all_day), 
+  //      0, false, MealTicketBehaviour.notAllowMealTicket, 0, null, 
+  //      Sets.newHashSet(), new LocalDate(2021, 11, 1), 
+  //      new LocalDate(2022, 2, 28), false, true, true),
+    
+  //  A_31_2021("31", "Ferie anno 2021 prorogate", false, 
+  //      ImmutableSet.of(JustifiedTypeName.all_day), 
+  //      0, false, MealTicketBehaviour.notAllowMealTicket, 0, null, 
+  //      Sets.newHashSet(), new LocalDate(2022, 11, 1), 
+  //      new LocalDate(2023, 2, 28), false, true, true),
+  
+  A_31_2022("31", "Ferie anno 2022 prorogate", false, 
       ImmutableSet.of(JustifiedTypeName.all_day), 
       0, false, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), LocalDate.of(2021, 11, 1), 
-      LocalDate.of(2022, 2, 28), false, true, true),
+      Sets.newHashSet(), LocalDate.of(2023, 11, 1), 
+      LocalDate.of(2024, 2, 28), false, true, true, "F"),
 
   A_31("31", "Ferie anno precedente", false, ImmutableSet.of(JustifiedTypeName.all_day), 0, false,
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
@@ -598,15 +614,15 @@ public enum DefaultAbsenceType {
   A_37("37", "ferie anno precedente (dopo il 31/8)", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true),
+      Sets.newHashSet(), null, null, false, true, true, "F"),
 
   A_91("91", "Riposo compensativo", false, ImmutableSet.of(JustifiedTypeName.all_day), 0, false,
       MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, true, true, true), 
+      Sets.newHashSet(), null, null, true, true, true, "F"), 
   A_91F("91F", "Riposo compensativo recupero giornata lavorativa festiva", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
-      null, null, true, true, true),
+      null, null, true, true, true, "F"),
 
   A_91CE("91", "Riposo compensativo per chiusura ente", false,
       ImmutableSet.of(JustifiedTypeName.recover_time), 0, false, 
@@ -1124,67 +1140,67 @@ public enum DefaultAbsenceType {
   A_111VM("111VM", "gg visite/terapie/prest. spec. <= 9MM malat", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
-      null, null, false, true, true), 
+      null, null, false, true, true, "F"), 
   A_111SCM("111SCM", "sosp.cautelare malattia <= 9mesi", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_119VM("119VM", "gg visite/terapie/prest. spec. > 9MM malat", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_115VM("115VM", "gg visite/terapie/prest. spec. > 12MM malat", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11S("11S", "Malattia superiore a 15 gg lav.", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_115("115", "Malattia superiore a 12 mesi", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_116("116", "Malattia superiore a 18 mesi", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0,
-      null, Sets.newHashSet(), null, null, false, true, true), 
+      null, Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_117("117", "Terapia invalidante grave patologia", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0,
-      null, Sets.newHashSet(), null, null, false, true, true), 
+      null, Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_118("118", "Malattia con responsabilita' di terzi", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true,
       MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_119("119", "Malattia superiore a nove mesi",
       false, ImmutableSet.of(JustifiedTypeName.all_day), 0,
       true, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11R("11R", "Malattia con ricovero", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0,
       true, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11R5("11R5", "Ricovero dopo malattia superiore a 12 mesi",
       false, ImmutableSet.of(JustifiedTypeName.all_day), 0,
       true, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11R9("11R9", "Ricovero dopo malattia superiore a 9 mesi",
       false, ImmutableSet.of(JustifiedTypeName.all_day),
       0, true, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11C("11C", "Malattia post-ricovero", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11C5("11C5", "Convalescenza dopo malattia superiore a 12 mesi",
       false, ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, "F"), 
   A_11C9("11C9", "Convalescenza dopo malattia superiore a 9 mesi",
       false, ImmutableSet.of(JustifiedTypeName.all_day),
       0, true, MealTicketBehaviour.notAllowMealTicket, 0, null, 
-      Sets.newHashSet(), null, null, false, true, true),
+      Sets.newHashSet(), null, null, false, true, true, "F"),
 
   A_12("12", "malattia primo figlio/a <= 3 anni retribuita 100%", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
@@ -1325,10 +1341,10 @@ public enum DefaultAbsenceType {
       ImmutableSet.of(JustifiedTypeName.nothing), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 420, 
       JustifiedTypeName.absence_type_minutes, Sets.newHashSet(), null, null, false, true, true), 
-  A_78("78", "permesso sindacale 8 ore", false,
-      ImmutableSet.of(JustifiedTypeName.nothing), 0, false, 
-      MealTicketBehaviour.notAllowMealTicket, 480, 
-      JustifiedTypeName.absence_type_minutes, Sets.newHashSet(), null, null, false, true, true),
+//  A_78("78", "permesso sindacale 8 ore", false,
+//      ImmutableSet.of(JustifiedTypeName.nothing), 0, false, 
+//      MealTicketBehaviour.notAllowMealTicket, 480, 
+//      JustifiedTypeName.absence_type_minutes, Sets.newHashSet(), null, null, false, true, true),
 
   A_71A("71A", "permesso sindacale 1 ora non retribuita", false,
       ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 60, false, 
@@ -1419,7 +1435,13 @@ public enum DefaultAbsenceType {
   A_77R("77R", "perm. sind. 7 ore R.S.U.", false,
       ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 420, false,
       MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), 
-      null, null, false, true, true),
+      null, null, false, true, true, null),
+  
+  A_7DM("7DM", "Permesso dirigenti sindacato in ore e minuti", true,
+      ImmutableSet.of(JustifiedTypeName.specified_minutes), 0, false, 
+      MealTicketBehaviour.allowMealTicket, 0, null,
+      Sets.newHashSet(new Behaviour(JustifiedBehaviourName.no_overtime)), null, null,
+      false, true, true, null), 
 
   A_71D("71D", "perm. sind. 1 ora dirigenti sidac.", false,
       ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 60, false, 
@@ -1446,13 +1468,13 @@ public enum DefaultAbsenceType {
       MealTicketBehaviour.allowMealTicket,
       0, null, Sets.newHashSet(), null, null, false, true, true), 
   A_77D("77D", "perm. sind. 7 ore dirigenti sindac.", false,
-      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
-      MealTicketBehaviour.allowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
-  A_78D("78D", "perm. sind. 8 ore dirigenti sindac.", false,
-      ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 480,
-      false, MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), 
-      null, null, false, true, true),
+      ImmutableSet.of(JustifiedTypeName.nothing), 0, false, 
+      MealTicketBehaviour.notAllowMealTicket, 420, JustifiedTypeName.absence_type_minutes,
+      Sets.newHashSet(), null, null, false, true, true, null), 
+//  A_78D("78D", "perm. sind. 8 ore dirigenti sindac.", false,
+//      ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 480,
+//      false, MealTicketBehaviour.allowMealTicket, 0, null, Sets.newHashSet(), 
+//      null, null, false, true, true),
 
   A_FA1("FA1", "formazione e aggiornamento 1 ora", false,
       ImmutableSet.of(JustifiedTypeName.absence_type_minutes), 60, false, 
@@ -1559,8 +1581,8 @@ public enum DefaultAbsenceType {
 
   A_441("441", "permesso esami", false, ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket,
-      0, null, Sets.newHashSet(), null, null, false, true, true), 
-  A_442("442", "permesso congr.conv.seminari ecc.", false, 
+      0, null, Sets.newHashSet(), null, null, false, true, true, null), 
+  A_442("442", "Permesso componenti commissione concorso altra amministrazione", false, 
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, MealTicketBehaviour.notAllowMealTicket, 
       0, null, Sets.newHashSet(), null, null, false, true, true), 
   A_6N("6N", "permesso motivi privati non retribuito", false,
@@ -1612,7 +1634,15 @@ public enum DefaultAbsenceType {
   A_62S50V("62S50V", "dist. sind.a temp. det. p. t. 50% vert.", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
-      null, null, false, true, true),
+      null, null, false, true, true, null),
+  A_62S25V("62S25V", "dist. sind.a temp. det. p. t. 25% vert.", false,
+      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
+      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
+      null, null, false, true, true, null),
+  A_62S75V("62S75V", "dist. sind.a temp. det. p. t. 75% vert.", false,
+      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
+      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
+      null, null, false, true, true, null),
 
   A_ES_L133("ES-L133", "esonero servizio art.72 L.133/08", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true, 
@@ -1642,7 +1672,13 @@ public enum DefaultAbsenceType {
   A_54("54", "aspett. per mot. di famigl.o studio", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, true /* festivo capire */, 
       MealTicketBehaviour.notAllowMealTicket, 0, null,
-      Sets.newHashSet(), null, null, false, true, true), 
+      Sets.newHashSet(), null, null, false, true, true, null), 
+  
+  A_54B("54B", "asp. assistenza figli <=6 anni", false,
+      ImmutableSet.of(JustifiedTypeName.all_day), 0, true /* festivo capire */, 
+      MealTicketBehaviour.notAllowMealTicket, 0, null,
+      Sets.newHashSet(), null, null, false, true, true, null), 
+  
   A_54C("54C", "aspett. per cooperaz. Paesi in sviluppo",
       false, ImmutableSet.of(JustifiedTypeName.all_day), 0, true /* festivo capire */, 
       MealTicketBehaviour.notAllowMealTicket, 0,
@@ -2371,19 +2407,32 @@ public enum DefaultAbsenceType {
   A_410("410", "Riposo compensativo missione Antartide", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(),
-      null, LocalDate.of(2021, 12, 31), false, true, true),
-  A_401("401", "Ferie missione Antartide anno precedente", false,
+      null, LocalDate.of(2021, 12, 31), false, true, true, null),
+//  A_402("402", "Ferie missione Antartide anno precedente", false,
+//      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
+//      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), null,
+//      new LocalDate(2023, 12, 31), false, true, true), 
+//  A_403("403", "Ferie missione Antartide anno corrente", false,
+//      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
+//      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
+//      new LocalDate(2023, 1, 1), new LocalDate(2024, 12, 31), false, true, true), 
+//  A_413("413", "Riposo compensativo missione Antartide", false,
+//      ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
+//      MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
+//      new LocalDate(2023, 1, 1), new LocalDate(2023, 12, 31), false, true, true), 
+  
+  A_403("403", "Ferie missione Antartide anno precedente", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), null,
-      LocalDate.of(2022, 12, 31), false, true, true), 
-  A_402("402", "Ferie missione Antartide anno corrente", false,
+      LocalDate.of(2024, 12, 31), false, true, true, "F"), 
+  A_404("404", "Ferie missione Antartide anno corrente", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
-      LocalDate.of(2022, 1, 1), LocalDate.of(2023, 12, 31), false, true, true), 
-  A_412("412", "Riposo compensativo missione Antartide", false,
+      LocalDate.of(2024, 1, 1), LocalDate.of(2025, 12, 31), false, true, true, "F"), 
+  A_414("414", "Riposo compensativo missione Antartide", false,
       ImmutableSet.of(JustifiedTypeName.all_day), 0, false, 
       MealTicketBehaviour.notAllowMealTicket, 0, null, Sets.newHashSet(), 
-      LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31), false, true, true), 
+      LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), false, true, true, "F"), 
 
 
   A_NC("NC", "Giorno non conteggiato ai fini del tempo a lavoro", true,
@@ -2453,9 +2502,11 @@ public enum DefaultAbsenceType {
   public LocalDate validTo; // nullable
 
   public Boolean reperibilityCompatible;
-  public Boolean isRealAbsenceType;
+  public boolean isRealAbsence;
 
   public boolean toUpdate;
+  
+  public String externalId = null;
 
   /**
    * DTO con i parametri predefiniti dei tipi di assenza.
@@ -2464,7 +2515,34 @@ public enum DefaultAbsenceType {
       Set<JustifiedTypeName> justifiedTypeNamesPermitted, Integer justifiedTime,
       boolean consideredWeekEnd, MealTicketBehaviour mealTicketBehaviour, Integer replacingTime,
       JustifiedTypeName replacingType, Set<Behaviour> behaviour, LocalDate validFrom,
-      LocalDate validTo, Boolean reperibilityCompatible, Boolean isRealAbsenceType,
+      LocalDate validTo, Boolean reperibilityCompatible, boolean isRealAbsence,
+      boolean toUpdate, String externalId) {
+    this.certificationCode = certificationCode;
+    this.description = description;
+    this.internalUse = internalUse;
+    this.justifiedTypeNamesPermitted = justifiedTypeNamesPermitted;
+    this.justifiedTime = justifiedTime;
+    this.consideredWeekEnd = consideredWeekEnd;
+    this.mealTicketBehaviour = mealTicketBehaviour;
+    this.replacingTime = replacingTime;
+    this.replacingType = replacingType;
+    this.behaviour = behaviour;
+    this.validFrom = validFrom;
+    this.validTo = validTo;
+    this.reperibilityCompatible = reperibilityCompatible;
+    this.isRealAbsence = isRealAbsence;
+    this.toUpdate = toUpdate;
+    this.externalId = externalId;
+  }
+
+  /**
+   * DTO con i parametri predefiniti dei tipi di assenza.
+   */
+  private DefaultAbsenceType(String certificationCode, String description, boolean internalUse,
+      Set<JustifiedTypeName> justifiedTypeNamesPermitted, Integer justifiedTime,
+      boolean consideredWeekEnd, MealTicketBehaviour mealTicketBehaviour, Integer replacingTime,
+      JustifiedTypeName replacingType, Set<Behaviour> behaviour, LocalDate validFrom,
+      LocalDate validTo, Boolean reperibilityCompatible, Boolean isRealAbsence,
       boolean toUpdate) {
     this.certificationCode = certificationCode;
     this.description = description;
@@ -2479,10 +2557,10 @@ public enum DefaultAbsenceType {
     this.validFrom = validFrom;
     this.validTo = validTo;
     this.reperibilityCompatible = reperibilityCompatible;
-    this.isRealAbsenceType = isRealAbsenceType;
+    this.isRealAbsence = isRealAbsence;
     this.toUpdate = toUpdate;
   }
-
+  
   /**
    * sottoclasse che definisce il comportamento.
    *

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultCategoryType.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultCategoryType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.Lists;
@@ -36,7 +35,9 @@ public enum DefaultCategoryType {
   FERIE_CNR("Ferie e permessi legge", 2, DefaultTab.FERIE_PERMESSI_RIPOSI), 
   //ESENZIONE_COVID19("Esenzione da lavoro causa COVID19", 3, DefaultTab.FERIE_PERMESSI_RIPOSI),
   RIPOSI_COMPENSATIVI_CNR("Riposi compensativi", 3, DefaultTab.FERIE_PERMESSI_RIPOSI),
-  PROROGA_FERIE_2020("Proroga ferie 2020", 4, DefaultTab.FERIE_PERMESSI_RIPOSI),
+  //  PROROGA_FERIE_2020("Proroga ferie 2020", 4, DefaultTab.FERIE_PERMESSI_RIPOSI),
+  //  PROROGA_FERIE_2021("Proroga ferie 2021", 4, DefaultTab.FERIE_PERMESSI_RIPOSI),
+  PROROGA_FERIE_2022("Proroga ferie 2022", 4, DefaultTab.FERIE_PERMESSI_RIPOSI),
   ASTENSIONE_POSTPARTUM("Astensione post partum", 5, DefaultTab.CONGEDI_PARENTALI), 
   CONGEDI_PRENATALI("Congedi prenatali", 7, DefaultTab.CONGEDI_PARENTALI),
 
@@ -70,7 +71,7 @@ public enum DefaultCategoryType {
 
   ALTRI_CODICI("Altri Codici", 16, DefaultTab.ALTRI_CODICI), 
   ASPETTATIVA("Codici Aspettativa", 17, DefaultTab.ALTRI_CODICI), 
-  PUBBLICA_FUNZIOINE("Pubblica Funzione", 18, DefaultTab.ALTRI_CODICI),
+  PUBBLICA_FUNZIONE("Pubblica Funzione", 18, DefaultTab.ALTRI_CODICI),
 
   LAVORO_FUORI_SEDE("Lavoro fuori sede", 17, DefaultTab.LAVORO_FUORI_SEDE), 
   FERIE_DIPENDENTI("Ferie e permessi legge", 18, DefaultTab.FERIE_DIPENDENTI), 

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultComplation.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultComplation.java
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.ImmutableSet;
@@ -89,8 +88,17 @@ public enum DefaultComplation {
           DefaultAbsenceType.A_74, 
           DefaultAbsenceType.A_75, 
           DefaultAbsenceType.A_76, 
-          DefaultAbsenceType.A_77, 
-          DefaultAbsenceType.A_78)),
+          DefaultAbsenceType.A_77)),
+  
+  C_7D(AmountType.minutes, 
+      ImmutableSet.of(DefaultAbsenceType.A_7DM), 
+      ImmutableSet.of(DefaultAbsenceType.A_71D, 
+          DefaultAbsenceType.A_72D, 
+          DefaultAbsenceType.A_73D, 
+          DefaultAbsenceType.A_74D, 
+          DefaultAbsenceType.A_75D, 
+          DefaultAbsenceType.A_76D, 
+          DefaultAbsenceType.A_77D)),
 
   C_661(AmountType.minutes, 
       ImmutableSet.of(DefaultAbsenceType.A_661MO, DefaultAbsenceType.A_661M), 
@@ -162,7 +170,11 @@ public enum DefaultComplation {
   C_43(AmountType.units, 
       ImmutableSet.of(DefaultAbsenceType.A_43), 
       ImmutableSet.of(DefaultAbsenceType.A_43)),
-
+  
+  C_45(AmountType.units, 
+      ImmutableSet.of(DefaultAbsenceType.A_45), 
+      ImmutableSet.of(DefaultAbsenceType.A_45)),
+  
   //  C_COV50(AmountType.units, 
   //      ImmutableSet.of(DefaultAbsenceType.A_COV50M), 
   //      ImmutableSet.of(DefaultAbsenceType.A_COV50H)),

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultGroup.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.Lists;
@@ -68,7 +67,7 @@ public enum DefaultGroup {
   G_19P("19P - Permesso provv. per dipendente disabile L. 104/92 tre giorni mese", "",
       DefaultCategoryType.PERMESSI_PROVVISORI_104, 0, GroupAbsenceTypePattern.programmed,
       PeriodType.month, DefaultTakable.T_19P, DefaultComplation.C_19P, null, false, false),
-
+  
   G_22("22 - Permesso 2h per figlio portatore di handicap con età <= 3 anni", "",
       DefaultCategoryType.ALTRI_104, 0, GroupAbsenceTypePattern.programmed, PeriodType.always,
       DefaultTakable.T_22, null, null, false, false),
@@ -127,6 +126,10 @@ public enum DefaultGroup {
   G_7("7 - Permessi sindacali", "", DefaultCategoryType.ALTRI_CODICI, 0, 
       GroupAbsenceTypePattern.programmed, PeriodType.year, DefaultTakable.T_PERMESSI_SINDACALI, 
       DefaultComplation.C_7, null, false, true),
+  
+  G_7D("7D - Permessi sindacali dirigenti", "", DefaultCategoryType.ALTRI_CODICI, 0, 
+      GroupAbsenceTypePattern.programmed, PeriodType.year, 
+      DefaultTakable.T_PERMESSI_SINDACALI_DIRIGENTI, DefaultComplation.C_7D, null, false, true),
 
   G_0("0 - Assemblea", "", DefaultCategoryType.ALTRI_CODICI, 0, GroupAbsenceTypePattern.programmed,
       PeriodType.year, DefaultTakable.T_0, DefaultComplation.C_0, null, false, true),
@@ -171,10 +174,18 @@ public enum DefaultGroup {
   //      GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, DefaultTakable.T_ESENZ_19, 
   //      null, null, false, false),
 
-  PROROGA_FERIE_2020("31_2020 - Proroga ferie 2020", "", 
-      DefaultCategoryType.PROROGA_FERIE_2020, 2, // must be greater than FERIE_CNR
+  //  PROROGA_FERIE_2020("31_2020 - Proroga ferie 2020", "", 
+  //      DefaultCategoryType.PROROGA_FERIE_2020, 2, // must be greater than FERIE_CNR
+  //      GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, 
+  //      DefaultTakable.T_FERIE_CNR_PROROGA_2020, null, null, false, false),
+  //  PROROGA_FERIE_2021("31_2021 - Proroga ferie 2021", "", 
+  //      DefaultCategoryType.PROROGA_FERIE_2021, 2, // must be greater than FERIE_CNR
+  //      GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, 
+  //      DefaultTakable.T_FERIE_CNR_PROROGA_2021, null, null, false, false),
+  PROROGA_FERIE_2022("31_2022 - Proroga ferie 2022", "", 
+      DefaultCategoryType.PROROGA_FERIE_2022, 2, // must be greater than FERIE_CNR
       GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, 
-      DefaultTakable.T_FERIE_CNR_PROROGA_2020, null, null, false, false),
+      DefaultTakable.T_FERIE_CNR_PROROGA_2022, null, null, false, false),
   FERIE_CNR_DIPENDENTI("Ferie e permessi legge", "",
       DefaultCategoryType.FERIE_DIPENDENTI, 2, // must be greater than FERIE_CNR
       GroupAbsenceTypePattern.vacationsCnr, PeriodType.always, DefaultTakable.T_FERIE_CNR, null,
@@ -345,9 +356,14 @@ public enum DefaultGroup {
   G_CONGEDI_PRENATALI("20/21 - Congedi Prenatali", "", DefaultCategoryType.CONGEDI_PRENATALI, 0,
       GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, DefaultTakable.T_CONGEDI_PRENATALI,
       null, null, false, false),
+  
+  G_54B("54B - Aspettativa assistenza figli minori di 6 anni 170 giorni",
+      "", DefaultCategoryType.ASPETTATIVA, 0, GroupAbsenceTypePattern.programmed,
+      PeriodType.year, DefaultTakable.T_54B, null,
+      null, false, true),
 
   G_CONGEDO_MATRIMONIO("45 - Congedo straordinario per matrimonio", "",
-      DefaultCategoryType.CONGEDO_MATRIMONIO, 0, GroupAbsenceTypePattern.simpleGrouping,
+      DefaultCategoryType.CONGEDO_MATRIMONIO, 0, GroupAbsenceTypePattern.programmed,
       PeriodType.always, DefaultTakable.T_CONGEDO_MATRIMONIO, null, null, false, false),
 
   G_441("441 - Permesso esami", "", DefaultCategoryType.PERMESSO_ESAMI, 0,
@@ -362,12 +378,12 @@ public enum DefaultGroup {
       GroupAbsenceTypePattern.programmed, PeriodType.year, DefaultTakable.T_20,
       DefaultComplation.C_20, null, false, false),
   
-  G_21P("21P - Congedo parentale per il padre da definire....",
+  G_21P("21P - Congedo paternità",
       "", DefaultCategoryType.ASTENSIONE_POSTPARTUM, 1, GroupAbsenceTypePattern.programmed,
       PeriodType.always, DefaultTakable.T_21P, null, null,
       false, true),
   
-  G_21P2("21P2 - Congedo parentale per il padre da definire....",
+  G_21P2("21P2 - Congedo paternità gemelli",
       "", DefaultCategoryType.ASTENSIONE_POSTPARTUM, 1, GroupAbsenceTypePattern.programmed,
       PeriodType.always, DefaultTakable.T_21P2, null, null,
       false, true),
@@ -389,7 +405,7 @@ public enum DefaultGroup {
       GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, 
       DefaultTakable.T_TELELAVORO_RT, null, null, false, false),
 
-  G_PUBBLICA_FUNZIONE("Codici Pubblica Funzione", "", DefaultCategoryType.PUBBLICA_FUNZIOINE, 2,
+  G_PUBBLICA_FUNZIONE("Codici Pubblica Funzione", "", DefaultCategoryType.PUBBLICA_FUNZIONE, 2,
       GroupAbsenceTypePattern.simpleGrouping, PeriodType.always, DefaultTakable.T_PUBBLICA_FUNZIONE,
       null, null, false, false),
 
@@ -421,7 +437,10 @@ public enum DefaultGroup {
       false, false), 
   G_683("683 - Permesso terzo lutto", "",
       DefaultCategoryType.PERMESSO_TERZO_LUTTO, 0, GroupAbsenceTypePattern.programmed,
-      PeriodType.year, DefaultTakable.T_683, null, null, false, false);
+      PeriodType.year, DefaultTakable.T_683, null, null, false, false),
+  G_662("662 - Permesso grave infermità coniuge o parente", "",
+      DefaultCategoryType.PERMESSI_PERSONALI, 0, GroupAbsenceTypePattern.programmed,
+      PeriodType.year, DefaultTakable.T_662, null, null, false, false);
 
   public String description;
   public String chainDescription;
@@ -546,7 +565,18 @@ public enum DefaultGroup {
   public static List<String> employeeSmartworking() {
     return getCodes(DefaultGroup.G_SMART);
   }
+
+  /**
+   * Ritorna la lista di codici da considerare per i congedi parentali per il padre.
+   */
   
+  public static List<String> parentalLeaveForFathers() {
+    List<String> g21p = getCodes(DefaultGroup.G_21P);
+    List<String> g21p2 = getCodes(DefaultGroup.G_21P2);
+
+    return Stream.of(g21p, g21p2).flatMap(x -> x.stream()).collect(Collectors.toList());
+  }
+
   /**
    * Ritorna la lista di codici da considerare per gli impiegati con 104.
    */
@@ -570,10 +600,6 @@ public enum DefaultGroup {
     List<String> g232 = getCodes(DefaultGroup.G_232);
     List<String> g233 = getCodes(DefaultGroup.G_233);
     List<String> g234 = getCodes(DefaultGroup.G_234);
-    //    List<String> g24 = getCodes(DefaultGroup.G_24);
-    //    List<String> g242 = getCodes(DefaultGroup.G_242);
-    //    List<String> g243 = getCodes(DefaultGroup.G_243);
-    //    List<String> g244 = getCodes(DefaultGroup.G_244);
     List<String> g25 = getCodes(DefaultGroup.G_25);
     List<String> g252 = getCodes(DefaultGroup.G_252);
     List<String> g253 = getCodes(DefaultGroup.G_253);

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultTab.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.Lists;

--- a/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultTakable.java
+++ b/src/main/java/it/cnr/iit/epas/models/absences/definitions/DefaultTakable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.models.absences.definitions;
 
 import com.google.common.collect.ImmutableSet;
@@ -94,20 +93,25 @@ public enum DefaultTakable {
       ImmutableSet.of(DefaultAbsenceType.A_21P2), 
       ImmutableSet.of(DefaultAbsenceType.A_21P2), 
       20, null),
-
+  
   T_22(AmountType.units,
       ImmutableSet.of(DefaultAbsenceType.A_22), 
       ImmutableSet.of(DefaultAbsenceType.A_22), 
       -1, null),
-
+  
   T_26(AmountType.units,
-      ImmutableSet.of(DefaultAbsenceType.A_26, DefaultAbsenceType.A_26BP), 
-      ImmutableSet.of(DefaultAbsenceType.A_26, DefaultAbsenceType.A_26BP), 
+      ImmutableSet.of(DefaultAbsenceType.A_26), 
+      ImmutableSet.of(DefaultAbsenceType.A_26), 
       -1, null),
   T_43(AmountType.units, 
       ImmutableSet.of(DefaultAbsenceType.A_43), 
       ImmutableSet.of(DefaultAbsenceType.A_43), 
       15, null),
+  
+  //  T_45(AmountType.units, 
+  //      ImmutableSet.of(DefaultAbsenceType.A_45), 
+  //      ImmutableSet.of(DefaultAbsenceType.A_45), 
+  //      15, null),
 
   T_C161718(AmountType.units,
       ImmutableSet.of(DefaultAbsenceType.A_C16, DefaultAbsenceType.A_C17, 
@@ -176,6 +180,11 @@ public enum DefaultTakable {
       ImmutableSet.of(DefaultAbsenceType.A_7M),
       -1, null),
   
+  T_PERMESSI_SINDACALI_DIRIGENTI(AmountType.minutes, 
+      ImmutableSet.of(DefaultAbsenceType.A_7DM),
+      ImmutableSet.of(DefaultAbsenceType.A_7DM),
+      -1, null),
+  
   T_MISSIONE(AmountType.minutes, 
       ImmutableSet.of(DefaultAbsenceType.A_92M),
       ImmutableSet.of(DefaultAbsenceType.A_92M),
@@ -209,11 +218,11 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_32, 
           DefaultAbsenceType.A_94), 
       -1, null),
-  
-  T_FERIE_CNR_PROROGA_2020(AmountType.units, 
-      ImmutableSet.of(DefaultAbsenceType.A_31_2020), 
-      ImmutableSet.of(DefaultAbsenceType.A_31_2020), 
-      -1, null),
+
+    T_FERIE_CNR_PROROGA_2022(AmountType.units, 
+        ImmutableSet.of(DefaultAbsenceType.A_31_2022), 
+        ImmutableSet.of(DefaultAbsenceType.A_31_2022), 
+        -1, null),
   
   T_FERIE_CNR_PROROGA(AmountType.units, 
       ImmutableSet.of(DefaultAbsenceType.A_31, 
@@ -257,6 +266,11 @@ public enum DefaultTakable {
       ImmutableSet.of(DefaultAbsenceType.A_103RT), 
       ImmutableSet.of(DefaultAbsenceType.A_103RT), 
       -1, null),
+  
+  T_54B(AmountType.units, 
+      ImmutableSet.of(DefaultAbsenceType.A_54B), 
+      ImmutableSet.of(DefaultAbsenceType.A_54B), 
+      170, null),
 
   T_23(AmountType.units, 
       ImmutableSet.of(DefaultAbsenceType.A_23, 
@@ -530,13 +544,14 @@ public enum DefaultTakable {
 
   T_ALTRI(AmountType.units, 
       ImmutableSet.of(
+          DefaultAbsenceType.A_COMANDO,
           DefaultAbsenceType.A_102,
           DefaultAbsenceType.A_103, DefaultAbsenceType.A_103BP, 
           DefaultAbsenceType.A_105BP,
 
           DefaultAbsenceType.A_71, DefaultAbsenceType.A_72, DefaultAbsenceType.A_73,
           DefaultAbsenceType.A_74, DefaultAbsenceType.A_75, DefaultAbsenceType.A_76,
-          DefaultAbsenceType.A_77, DefaultAbsenceType.A_78,
+          DefaultAbsenceType.A_77, 
 
           DefaultAbsenceType.A_71A, DefaultAbsenceType.A_72A, 
           DefaultAbsenceType.A_73A, DefaultAbsenceType.A_74A, DefaultAbsenceType.A_75A, 
@@ -552,7 +567,7 @@ public enum DefaultTakable {
 
           DefaultAbsenceType.A_71D, DefaultAbsenceType.A_72D, 
           DefaultAbsenceType.A_73D, DefaultAbsenceType.A_74D, DefaultAbsenceType.A_75D, 
-          DefaultAbsenceType.A_76D, DefaultAbsenceType.A_77D, DefaultAbsenceType.A_78D,
+          DefaultAbsenceType.A_76D, DefaultAbsenceType.A_77D, 
 
           DefaultAbsenceType.A_FA1, DefaultAbsenceType.A_FA2, 
           DefaultAbsenceType.A_FA3, DefaultAbsenceType.A_FA4, DefaultAbsenceType.A_FA5, 
@@ -574,24 +589,25 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_83, DefaultAbsenceType.A_84, 
           DefaultAbsenceType.A_85, DefaultAbsenceType.A_86,
           DefaultAbsenceType.A_87, DefaultAbsenceType.A_662,
-          DefaultAbsenceType.A_62S50V, DefaultAbsenceType.A_ES_L133,
+          DefaultAbsenceType.A_62S50V, DefaultAbsenceType.A_62S25V,
+          DefaultAbsenceType.A_62S75V, DefaultAbsenceType.A_ES_L133,
           DefaultAbsenceType.A_99, DefaultAbsenceType.A_65, DefaultAbsenceType.A_61,
           DefaultAbsenceType.A_16, DefaultAbsenceType.A_42, DefaultAbsenceType.A_93,
           DefaultAbsenceType.A_408, DefaultAbsenceType.A_50,
           DefaultAbsenceType.A_NC, DefaultAbsenceType.A_62, DefaultAbsenceType.A_35R,
           DefaultAbsenceType.A_96, DefaultAbsenceType.A_96A, DefaultAbsenceType.A_96B,
           DefaultAbsenceType.A_98, DefaultAbsenceType.A_52, DefaultAbsenceType.A_100,
-          DefaultAbsenceType.A_401, DefaultAbsenceType.A_412,
-          DefaultAbsenceType.A_402, DefaultAbsenceType.A_62,
+          DefaultAbsenceType.A_403, DefaultAbsenceType.A_404,DefaultAbsenceType.A_414,
+          DefaultAbsenceType.A_62,
           DefaultAbsenceType.A_62A, DefaultAbsenceType.A_62D, DefaultAbsenceType.A_98CV, 
           DefaultAbsenceType.A_39LA, DefaultAbsenceType.A_46,
           DefaultAbsenceType.A_46RA, DefaultAbsenceType.A_VAC19),
-          ImmutableSet.of(DefaultAbsenceType.A_102,
+          ImmutableSet.of(DefaultAbsenceType.A_COMANDO, DefaultAbsenceType.A_102,
           DefaultAbsenceType.A_103, DefaultAbsenceType.A_103BP, 
           DefaultAbsenceType.A_105BP,
           DefaultAbsenceType.A_71, DefaultAbsenceType.A_72, DefaultAbsenceType.A_73,
           DefaultAbsenceType.A_74, DefaultAbsenceType.A_75, DefaultAbsenceType.A_76,
-          DefaultAbsenceType.A_77, DefaultAbsenceType.A_78,
+          DefaultAbsenceType.A_77, 
           DefaultAbsenceType.A_71A, DefaultAbsenceType.A_72A, 
           DefaultAbsenceType.A_73A, DefaultAbsenceType.A_74A, DefaultAbsenceType.A_75A, 
           DefaultAbsenceType.A_76A, DefaultAbsenceType.A_77A, DefaultAbsenceType.A_78A,
@@ -603,7 +619,7 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_76R, DefaultAbsenceType.A_77R,
           DefaultAbsenceType.A_71D, DefaultAbsenceType.A_72D, 
           DefaultAbsenceType.A_73D, DefaultAbsenceType.A_74D, DefaultAbsenceType.A_75D, 
-          DefaultAbsenceType.A_76D, DefaultAbsenceType.A_77D, DefaultAbsenceType.A_78D,
+          DefaultAbsenceType.A_76D, DefaultAbsenceType.A_77D, 
           DefaultAbsenceType.A_FA1, DefaultAbsenceType.A_FA2, 
           DefaultAbsenceType.A_FA3, DefaultAbsenceType.A_FA4, DefaultAbsenceType.A_FA5, 
           DefaultAbsenceType.A_FA6, DefaultAbsenceType.A_FA7,
@@ -619,15 +635,16 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_83, DefaultAbsenceType.A_84, 
           DefaultAbsenceType.A_85, DefaultAbsenceType.A_86,
           DefaultAbsenceType.A_87, DefaultAbsenceType.A_662,
-          DefaultAbsenceType.A_62S50V, DefaultAbsenceType.A_ES_L133,
+          DefaultAbsenceType.A_62S50V, DefaultAbsenceType.A_62S25V,
+          DefaultAbsenceType.A_62S75V, DefaultAbsenceType.A_ES_L133,
           DefaultAbsenceType.A_99, DefaultAbsenceType.A_65, DefaultAbsenceType.A_61,
           DefaultAbsenceType.A_16, DefaultAbsenceType.A_42, DefaultAbsenceType.A_93,
           DefaultAbsenceType.A_408, DefaultAbsenceType.A_50,
           DefaultAbsenceType.A_NC, DefaultAbsenceType.A_62, DefaultAbsenceType.A_35R,
           DefaultAbsenceType.A_96, DefaultAbsenceType.A_96A, DefaultAbsenceType.A_96B,
           DefaultAbsenceType.A_98, DefaultAbsenceType.A_52, DefaultAbsenceType.A_100,
-          DefaultAbsenceType.A_401, DefaultAbsenceType.A_412,
-          DefaultAbsenceType.A_402, DefaultAbsenceType.A_62,
+          DefaultAbsenceType.A_403, DefaultAbsenceType.A_404,DefaultAbsenceType.A_414,
+          DefaultAbsenceType.A_62,
           DefaultAbsenceType.A_62A, DefaultAbsenceType.A_62D, DefaultAbsenceType.A_98CV,
           DefaultAbsenceType.A_39LA, DefaultAbsenceType.A_46,
           DefaultAbsenceType.A_46RA, DefaultAbsenceType.A_VAC19),
@@ -636,7 +653,7 @@ public enum DefaultTakable {
   T_CONGEDO_MATRIMONIO(AmountType.units, 
       ImmutableSet.of(DefaultAbsenceType.A_45), 
       ImmutableSet.of(DefaultAbsenceType.A_45), 
-      -1, null),
+      15, null),
 
   T_681(AmountType.units,
       ImmutableSet.of(DefaultAbsenceType.A_681),
@@ -649,6 +666,11 @@ public enum DefaultTakable {
   T_683(AmountType.units,
       ImmutableSet.of(DefaultAbsenceType.A_683),
       ImmutableSet.of(DefaultAbsenceType.A_683),
+      3, null),
+  
+  T_662(AmountType.units,
+      ImmutableSet.of(DefaultAbsenceType.A_662),
+      ImmutableSet.of(DefaultAbsenceType.A_662),
       3, null),
   
   T_6N(AmountType.units, 
@@ -756,9 +778,11 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_132, DefaultAbsenceType.A_133, 
           DefaultAbsenceType.A_14, DefaultAbsenceType.A_142, 
           DefaultAbsenceType.A_143, DefaultAbsenceType.A_54A17,
-          //DefaultAbsenceType.A_17C,
+          DefaultAbsenceType.A_98CV,
           DefaultAbsenceType.A_C17, DefaultAbsenceType.A_C18,
-          DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R), 
+          DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R,
+          DefaultAbsenceType.A_54B, DefaultAbsenceType.A_62S50V, 
+          DefaultAbsenceType.A_62S25V,DefaultAbsenceType.A_62S75V), 
       ImmutableSet.of(
           DefaultAbsenceType.A_24, DefaultAbsenceType.A_24H7,
           DefaultAbsenceType.A_25O, DefaultAbsenceType.A_25OH7,
@@ -778,9 +802,11 @@ public enum DefaultTakable {
           DefaultAbsenceType.A_132, DefaultAbsenceType.A_133, 
           DefaultAbsenceType.A_14, DefaultAbsenceType.A_142, 
           DefaultAbsenceType.A_143, DefaultAbsenceType.A_54A17,
-          //DefaultAbsenceType.A_17C,
+          DefaultAbsenceType.A_98CV,
           DefaultAbsenceType.A_C17, DefaultAbsenceType.A_C18,
-          DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R), 
+          DefaultAbsenceType.A_C16, DefaultAbsenceType.A_35R,
+          DefaultAbsenceType.A_54B, DefaultAbsenceType.A_62S50V, 
+          DefaultAbsenceType.A_62S25V,DefaultAbsenceType.A_62S75V), 
       -1, null),
 
   T_RIPOSI_CNR_ATTESTATI(AmountType.units, 

--- a/src/main/java/it/cnr/iit/epas/security/SecurityRules.java
+++ b/src/main/java/it/cnr/iit/epas/security/SecurityRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022  Consiglio Nazionale delle Ricerche
+ * Copyright (C) 2024  Consiglio Nazionale delle Ricerche
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as
@@ -14,10 +14,10 @@
  *     You should have received a copy of the GNU Affero General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package it.cnr.iit.epas.security;
 
 import com.google.common.collect.Lists;
+import it.cnr.iit.epas.dao.history.HistoricalDao;
 import it.cnr.iit.epas.models.User;
 import it.cnr.iit.epas.models.UsersRolesOffices;
 import it.cnr.iit.epas.models.enumerate.AccountRole;
@@ -49,19 +49,22 @@ public class SecurityRules {
   private static final String CURRENT_USER = "currentUser";
   private static final String CURRENT_ROLES = "userRoles";
   private static final String CURRENT_ROLES_OFFICES = "userRolesOffices";
-
+  private static final String HISTORICAL_DAO = "historicalDao";
 
   private final KieBase kieBase;
   private final SecureUtils secureUtils;
   private final RequestScopeData requestScope;
+  private final HistoricalDao historicalDao;
 
   private static final Pattern PATH_PARAMS_PATTERN = Pattern.compile(":.*?}");
 
   @Inject
-  SecurityRules(KieBase kieBase, SecureUtils secureUtils, RequestScopeData requestScope) {
+  SecurityRules(KieBase kieBase, SecureUtils secureUtils, RequestScopeData requestScope, 
+      HistoricalDao historicalDao) {
     this.kieBase = kieBase;
     this.secureUtils = secureUtils;
     this.requestScope = requestScope;
+    this.historicalDao = historicalDao;
   }
 
   public void checkifPermitted() {
@@ -126,6 +129,7 @@ public class SecurityRules {
     session.setGlobal(CURRENT_USER, user);
     session.setGlobal(CURRENT_ROLES, userRoles);
     session.setGlobal(CURRENT_ROLES_OFFICES, userRolesOffices);
+    session.setGlobal(HISTORICAL_DAO, historicalDao);
     session.addEventListener(new AgendaLogger());
 
     commands.add(CommandFactory.newInsert(check.getTarget()));

--- a/src/main/resources/permissions.drl
+++ b/src/main/resources/permissions.drl
@@ -1,12 +1,15 @@
+import org.joda.time.YearMonth;
 import it.cnr.iit.epas.security.PermissionCheck
 import it.cnr.iit.epas.models.enumerate.AccountRole
 import it.cnr.iit.epas.models.UsersRolesOffices;
+import it.cnr.iit.epas.models.absences.Absence;
 import it.cnr.iit.epas.models.Office;
 import it.cnr.iit.epas.models.Person;
 import it.cnr.iit.epas.models.Role;
 import it.cnr.iit.epas.models.PersonReperibility;
 import it.cnr.iit.epas.models.PersonReperibilityType;
 import it.cnr.iit.epas.models.Configuration;
+import it.cnr.iit.epas.models.PersonConfiguration;
 import it.cnr.iit.epas.models.ReperibilityTypeMonth;
 import it.cnr.iit.epas.manager.configurations.EpasParam;
 
@@ -148,6 +151,228 @@ when
 then
  $c.grant();
 end
+
+/*******************************************************************************
+ * Azioni utente per inserimento assenze
+ ******************************************************************************/
+/*
+ * L'amministratore del personale può modificare una determinata assenza se:
+ */
+rule AdminCanEditAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.PERSONNEL_ADMIN) from $uro.role
+ $a: Absence()
+ $at: Person() from $a.getOwner()
+ $target: Office(persons contains $at) from $uro.office
+ $c: PermissionCheck(
+     permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST'),
+     toCheck(), target == $target)
+then
+ $c.grant();
+end
+
+/* Azioni eseguibili da qualsiasi utente che abbiano come destinatario
+ * dell'azione se stesso
+*/
+rule HasRightOnHimselfExceptFor
+when
+  $p: Person(user == currentUser)
+  $c: PermissionCheck(
+      !permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod != 'POST',
+      toCheck(), target == $p, granted == false)
+then
+ $c.grant();
+end
+
+
+/*
+ * L'Amministratore del personale in sola lettura può fare quasi tutto sulle persone del proprio ufficio
+ */
+rule HasRightOnPerson
+when
+  $uro: UsersRolesOffices(role.name == Role.PERSONNEL_ADMIN_MINI)
+  $o: Office() from $uro.office
+  $c: PermissionCheck(
+      !permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod != 'POST',
+      toCheck(), $o.persons contains target, granted == false)
+then
+ $c.grant();
+end
+
+
+rule OnlyForPersonnelAdmin_Generic
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.PERSONNEL_ADMIN) from $uro.role
+ $c: PermissionCheck(
+    (permission.startsWith("/rest/v4/absencesGroups/groupsForCategory") && httpMethod.equalsIgnoreCase('GET')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/findCode") && httpMethod.equalsIgnoreCase('GET')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+    toCheck(), target == null, granted == false)
+then
+ $c.grant();
+end
+
+rule OnlyForPersonnelAdmin_InOffice
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.PERSONNEL_ADMIN) from $uro.role
+ $o: Office(usersRolesOffices contains $uro)
+ $c: PermissionCheck(
+    (permission.startsWith("/rest/v4/absencesGroups/groupsForCategory") && httpMethod.equalsIgnoreCase('POST')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/findCode") && httpMethod.equalsIgnoreCase('GET')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+    toCheck(), target == $o, granted == false)
+then
+ $c.grant();
+end
+
+/************************************************************************************
+ * L'amministratore può inserire le timbrature nel passato senza limiti (per ora)
+ * il controllo che non sia una data futura viene fatta nell'action (sulle stampings)
+ ************************************************************************************/
+rule adminCanInsertStampingsAndAbsences_inDate
+when
+  $uro: UsersRolesOffices() from userRolesOffices
+  Role(name == Role.PERSONNEL_ADMIN) from $uro.role
+  $target: YearMonth()
+  $c: PermissionCheck(
+      !permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod != 'POST',
+      toCheck(), target == $target, granted == false)
+then
+ $c.grant();
+end
+
+/**************************************************************************************
+ * Azioni per utente employee abilitato alla assenza lavoro fuori sede con convenzione
+ **************************************************************************************/
+rule Working_offsite_with_convention
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.WORKING_OFF_SITE, fieldValue == true) from $o.configurations
+ PersonConfiguration(epasParam == EpasParam.OFF_SITE_ABSENCE_WITH_CONVENTION, fieldValue == true) from $p.personConfigurations
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == null, granted == false)
+then
+ $c.grant();
+end
+
+/**************************************
+ * Azioni per utente employee abilitato
+ **************************************/
+rule Absences_person
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.ADDITIONAL_HOURS
+ 				|| epasParam == EpasParam.COVID_19
+ 				|| epasParam == EpasParam.RIGHT_TO_STUDY
+ 				|| epasParam == EpasParam.DISABLED_PERSON_PERMISSION
+ 				|| epasParam == EpasParam.DISABLED_RELATIVE_PERMISSION
+ 				|| epasParam == EpasParam.TELEWORK
+ 				|| epasParam == EpasParam.ENABLE_TELEWORK_STAMPINGS_FOR_WORKTIME
+ 				|| epasParam == EpasParam.AGILE_WORK_OR_DISABLED_PEOPLE_ASSISTANCE
+ 				|| epasParam == EpasParam.SMARTWORKING
+ 				|| epasParam == EpasParam.PARENTAL_LEAVE_FOR_FATHERS && fieldValue == true) from $p.personConfigurations
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == null, granted == false)
+then
+ $c.grant();
+end
+
+/********************************************************
+ * Azioni per utente employee abilitato per visita medica
+ ********************************************************/
+rule Absences_person_medical_exam
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.PEOPLE_ALLOWED_INSERT_MEDICAL_EXAM && fieldValue == true) from $o.configurations
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == null, granted == false)
+then
+ $c.grant();
+end
+
+/************************************************************************************
+ * Un dipendente può autocertificare le proprie assenze per il lavoro fuori Sede se...
+ ***********************************************************************************/
+rule employeeCanInsertAbsencesOffsiteWithConvention
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.WORKING_OFF_SITE, fieldValue == true) from $o.configurations
+ PersonConfiguration(epasParam == EpasParam.OFF_SITE_ABSENCE_WITH_CONVENTION, fieldValue == true) from $p.personConfigurations
+ $c: PermissionCheck(
+ permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST'),
+ toCheck(), target == $p, granted == false)
+then
+ $c.grant();
+end
+
+/************************************************************
+ * Un dipendente può autocertificare le proprie assenze se...
+ ************************************************************/
+rule employeeCanInsertAbsences
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration((epasParam == EpasParam.COVID_19 && fieldValue == true)
+ 				|| (epasParam == EpasParam.DISABLED_PERSON_PERMISSION && fieldValue == true)
+ 				|| (epasParam == EpasParam.DISABLED_RELATIVE_PERMISSION && fieldValue == true)
+ 				|| (epasParam == EpasParam.RIGHT_TO_STUDY && fieldValue == true)
+ 				|| (epasParam == EpasParam.TELEWORK && fieldValue == true)
+ 				|| (epasParam == EpasParam.ADDITIONAL_HOURS && fieldValue == true)
+ 				|| (epasParam == EpasParam.PARENTAL_LEAVE_AND_CHILD_ILLNESS && fieldValue == true)
+ 				|| (epasParam == EpasParam.SECOND_DISABLED_RELATIVE_PERMISSION && fieldValue == true)
+ 				|| (epasParam == EpasParam.AGILE_WORK_OR_DISABLED_PEOPLE_ASSISTANCE && fieldValue == true)
+ 				|| (epasParam == EpasParam.SMARTWORKING && fieldValue == true)
+ 				|| (epasParam == EpasParam.AGILE_WORK && fieldValue == true)
+ 				|| (epasParam == EpasParam.PARENTAL_LEAVE_FOR_FATHERS && fieldValue == true)) from $p.personConfigurations
+ $c: PermissionCheck(
+ permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST'),
+     toCheck(), target == $p, granted == false)
+then
+ $c.grant();
+end
+
+/******************************************************************************
+ * Un dipendente può autocertificare le proprie assenze per visita medica se...
+ *****************************************************************************/
+
+rule employeeCanInsertMedicalExam
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.PEOPLE_ALLOWED_INSERT_MEDICAL_EXAM && fieldValue == true) from $o.configurations
+ $c: PermissionCheck(
+      permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST'),
+      toCheck(), target == $p, granted == false)
+then
+ $c.grant();
+end
+
+
 
 /*******************************************************************************
  * Azioni utente con ruolo BADGE_READER

--- a/src/main/resources/permissions.drl
+++ b/src/main/resources/permissions.drl
@@ -18,6 +18,7 @@ import it.cnr.iit.epas.manager.configurations.EpasParam;
 global it.cnr.iit.epas.models.User currentUser;
 global java.util.Set userRoles;
 global java.util.List userRolesOffices;
+global it.cnr.iit.epas.dao.history.HistoricalDao historicalDao;
 
 /*******************************************************************************
  * Azioni ruolo DEVELOPER e ADMIN
@@ -387,13 +388,11 @@ when
  PersonConfiguration(epasParam == EpasParam.OFF_SITE_ABSENCE_WITH_CONVENTION, fieldValue == true) from $p.personConfigurations
  /** Sostituire il metodo che valuta che tipo di assenza può inserire il dipendente utilizzando la nuova modellazione **/
  $target: Absence(DefaultGroup.employeeOffSeatCodes() contains this.getCode(), this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$h.isPersistent($target) ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval(!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth())
  )
 then
@@ -410,13 +409,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.DISABLED_PERSON_PERMISSION, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeDisabledPersonCodes() contains this.getCode(), this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -433,13 +430,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.TELEWORK, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeTeleworkCodes() contains this.getCode(), this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -455,13 +450,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.DISABLED_PERSON_PERMISSION, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeDisabledRelativeCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -477,13 +470,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.RIGHT_TO_STUDY, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeRightToStudyCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -499,13 +490,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.COVID_19, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeCovid19Codes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -521,13 +510,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.AGILE_WORK, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeAgileCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -543,13 +530,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.ADDITIONAL_HOURS, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeAdditionalHoursCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -565,13 +550,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.PARENTAL_LEAVE_AND_CHILD_ILLNESS, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.parentalLeaveAndChildIllnessCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -587,13 +570,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.SECOND_DISABLED_RELATIVE_PERMISSION, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeSecondDisabledRelativeCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -609,13 +590,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.AGILE_WORK_OR_DISABLED_PEOPLE_ASSISTANCE, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeAgileWorkOrDisabledPeopleAssistanceCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -631,13 +610,11 @@ when
  $p: Person() from currentUser.getPerson()
  PersonConfiguration(epasParam == EpasParam.SMARTWORKING, fieldValue == true) from $p.personConfigurations
  $target: Absence(DefaultGroup.employeeSmartworking() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();
@@ -654,13 +631,11 @@ when
  $o: Office() from $p.office
  Configuration(epasParam == EpasParam.PEOPLE_ALLOWED_INSERT_MEDICAL_EXAM, fieldValue == true) from $o.configurations
  $target: Absence(DefaultGroup.medicalExamsCodes() contains this.getCode() , this.getOwner() == $p)
- $h: HistoricalDao()
- $c: PermissionCheck(
+  $c: PermissionCheck(
       (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
       (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
       toCheck(), target == $target, granted == false )
- eval (//!$target.isPersistent() ||
- $h.lastRevisionOperator($target) == currentUser)
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
  eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
 then
  $c.grant();

--- a/src/main/resources/permissions.drl
+++ b/src/main/resources/permissions.drl
@@ -620,6 +620,26 @@ then
  $c.grant();
 end
 
+/***********************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per congedo parentale per il padre 
+ ***********************************************************************************************/
+rule EmployeeCanEditParentalLeaveForFatherAbsence
+when
+ $uro: UsersRolesOffices(role.name == Role.EMPLOYEE)
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.PARENTAL_LEAVE_FOR_FATHERS, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.parentalLeaveForFathers().contains(this.getCode()), this.getOwner() == $p)
+ $c: PermissionCheck(
+    (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+    (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+    toCheck(), target == $target, granted == false )
+ //$c: PermissionCheck(action in ("AbsenceGroups.insert", "AbsenceGroups.edit", "AbsenceGroups.save", "AbsenceGroups.delete"), target == $target, granted == false )
+ eval (!historicalDao.isPersistent($target) || historicalDao.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
 /*****************************************************************************************************
  * L'impiegato può modificare/salvare una determinata assenza per visita medica se:
  **********************************************************************************/

--- a/src/main/resources/permissions.drl
+++ b/src/main/resources/permissions.drl
@@ -1,8 +1,10 @@
-import org.joda.time.YearMonth;
+import java.time.YearMonth;
+import it.cnr.iit.epas.dao.history.HistoricalDao;
 import it.cnr.iit.epas.security.PermissionCheck
 import it.cnr.iit.epas.models.enumerate.AccountRole
 import it.cnr.iit.epas.models.UsersRolesOffices;
 import it.cnr.iit.epas.models.absences.Absence;
+import it.cnr.iit.epas.models.absences.definitions.DefaultGroup;
 import it.cnr.iit.epas.models.Office;
 import it.cnr.iit.epas.models.Person;
 import it.cnr.iit.epas.models.Role;
@@ -372,7 +374,315 @@ then
  $c.grant();
 end
 
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per lavoro fuori sede in convenzione se:
+ *****************************************************************************************************/
+rule EmployeeCanEditOffSiteAbsenceWithConvention
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.WORKING_OFF_SITE, fieldValue == true) from $o.configurations
+ PersonConfiguration(epasParam == EpasParam.OFF_SITE_ABSENCE_WITH_CONVENTION, fieldValue == true) from $p.personConfigurations
+ /** Sostituire il metodo che valuta che tipo di assenza può inserire il dipendente utilizzando la nuova modellazione **/
+ $target: Absence(DefaultGroup.employeeOffSeatCodes() contains this.getCode(), this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$h.isPersistent($target) ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth())
+ )
+then
+ $c.grant();
+end
 
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per legge 104 se:
+ *******************************************************************************/
+ rule EmployeeCanEditDisabledPersonAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.DISABLED_PERSON_PERMISSION, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeDisabledPersonCodes() contains this.getCode(), this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+
+ /*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per telelavoro se:
+ *******************************************************************************/
+rule EmployeeCanEditTeleworkAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.TELEWORK, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeTeleworkCodes() contains this.getCode(), this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per legge 104 per parente disabile se:
+  ***************************************************************************************************/
+rule EmployeeCanEditDisabledRelativeAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.DISABLED_PERSON_PERMISSION, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeDisabledRelativeCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per diritto allo studio se:
+ ****************************************************************************************/
+rule EmployeeCanEditRightToStudyAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.RIGHT_TO_STUDY, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeRightToStudyCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per emergenza COVID19 se:
+ **************************************************************************************/
+rule EmployeeCanEditCovid19Absence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.COVID_19, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeCovid19Codes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per L-AGILE di cui alla nota del DG 22278 del 22 marzo 2022 se:
+***************************************************************************************************************************/
+ rule EmployeeCanEditAgileWorkAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.AGILE_WORK, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeAgileCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per ore aggiuntive se:
+ ***********************************************************************************/
+rule EmployeeCanEditAdditionalHourAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.ADDITIONAL_HOURS, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeAdditionalHoursCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per congedo parentale/malattia figlio se:
+ ******************************************************************************************************/
+rule EmployeeCanEditParentalLeaveAndChildIllnessAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.PARENTAL_LEAVE_AND_CHILD_ILLNESS, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.parentalLeaveAndChildIllnessCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per secondo parente disabile se:
+ *********************************************************************************************/
+rule EmployeeCanEditSecondDisabledRelativeAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.SECOND_DISABLED_RELATIVE_PERMISSION, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeSecondDisabledRelativeCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per lavoro agile per dipendenti fragili o assistenza disabile/immunodepresso:
+ ******************************************************************************************************************************************/
+rule EmployeeCanEditAgileWorkOrDisabledPeopleAssistanceAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.AGILE_WORK_OR_DISABLED_PEOPLE_ASSISTANCE, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeAgileWorkOrDisabledPeopleAssistanceCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+* L'impiegato può modificare/salvare una determinata assenza per lavoro agile
+******************************************************************************/
+rule EmployeeCanEditSmartworkingAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ PersonConfiguration(epasParam == EpasParam.SMARTWORKING, fieldValue == true) from $p.personConfigurations
+ $target: Absence(DefaultGroup.employeeSmartworking() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * L'impiegato può modificare/salvare una determinata assenza per visita medica se:
+ **********************************************************************************/
+rule EmployeeCanEditMedicalExamAbsence
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $o: Office() from $p.office
+ Configuration(epasParam == EpasParam.PEOPLE_ALLOWED_INSERT_MEDICAL_EXAM, fieldValue == true) from $o.configurations
+ $target: Absence(DefaultGroup.medicalExamsCodes() contains this.getCode() , this.getOwner() == $p)
+ $h: HistoricalDao()
+ $c: PermissionCheck(
+      (permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST')) ||
+      (permission.startsWith("/rest/v4/absencesGroups/save") && httpMethod.equalsIgnoreCase('POST')),
+      toCheck(), target == $target, granted == false )
+ eval (//!$target.isPersistent() ||
+ $h.lastRevisionOperator($target) == currentUser)
+ eval($target.getYearMonth().isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target.getYearMonth()))
+then
+ $c.grant();
+end
+
+/*****************************************************************************************************
+ * Un dipendente può autocertificare le proprie timbrature entro una certa data se...
+ * Non vengono fatti i controlli sulle configurazioni che vengono già fatti nelle altre drools
+ * in modo che questa regola valga sia nel caso di
+ **********************************************************************************/
+rule employeeCanInsertStampings_inDate
+when
+ $uro: UsersRolesOffices() from userRolesOffices
+ Role(name == Role.EMPLOYEE) from $uro.role
+ $p: Person() from currentUser.getPerson()
+ $target: YearMonth()
+ $c: PermissionCheck(permission.startsWith("/rest/v4/absencesGroups/insertSimulation") && httpMethod.equalsIgnoreCase('POST'), target == $target, granted == false)
+ /** non più indietro di 2 mesi fa e solo nei mesi non ancora inviati sugli attestati **/
+ eval($target.isAfter(YearMonth.now().minusMonths(2)) && $p.checkLastCertificationDate($target))
+then
+ $c.grant();
+end
 
 /*******************************************************************************
  * Azioni utente con ruolo BADGE_READER


### PR DESCRIPTION
sviluppate api per:
- recupero informazioni per popolare la form delle assenze
-  simulazione dell'inserimento assenza
-  findcode
- aggiunta nuova assenza
aggiunte anche le drools basandomi sulle drools del vechcio epas, però la drools EmployeeCanEditParentalLeaveForFatherAbsence dava errore in compilazione perchè in models.absence.definition.DefaultGroup non esiste il metodo parentalLeaveForFathers

inoltre non sono riuscito a gestire nelle drools eval (!$target.isPersistent()) che da sempre errore per HistoricalDao 